### PR TITLE
Post 요청을 통해 스토리 아이템을 추가할 수 있으며, 기존 스토리 아이템을 가져올 수 있다

### DIFF
--- a/client/src/components/KanbanTodo/index.tsx
+++ b/client/src/components/KanbanTodo/index.tsx
@@ -6,11 +6,7 @@ import useInput from '@/lib/hooks/useInput';
 import Styled from '@/components/KanbanTodo/style';
 import Button from '@/lib/design/Button';
 
-enum StatusType {
-  TODO,
-  IN_PRGORESS,
-  DONE,
-}
+type StatusType = 'TODO' | 'IN_PROGRESS' | 'DONE';
 interface StoryObject {
   id: number;
   name: string;

--- a/client/src/components/KanbanTodo/index.tsx
+++ b/client/src/components/KanbanTodo/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useStoryState, useStoryDispatch } from '@/lib/hooks/useContextHooks';
-import { useUserState } from '@/lib/hooks/useContextHooks';
 import { createStory } from '@/lib/api/story';
 import useInput from '@/lib/hooks/useInput';
 import Styled from '@/components/KanbanTodo/style';
@@ -16,7 +15,6 @@ interface StoryObject {
 const KanbanTodo = () => {
   const storyArray = useStoryState();
   const useDispatch = useStoryDispatch();
-  const userState = useUserState();
 
   const [value, onChange] = useInput();
   const lastStoryId = storyArray.length > 0 ? storyArray[storyArray.length - 1]?.id : 0;
@@ -25,11 +23,15 @@ const KanbanTodo = () => {
     name: '',
     status: 'TODO',
   };
-  console.log(userState);
 
   const addStory = () => {
     useDispatch({ type: 'ADD_STORY', story: StoryObject });
-    createStory(StoryObject.id, StoryObject.status, userState.currentProjectId as number, '', '');
+
+    //todo 현재 CurrentProjectId 와 EPIC ID 를 하드코딩함
+    // CurrentProjectID 는 세션으로 유저 정보 조회 후 가져올 예정
+    // EPIC ID 는 DB 에 저장 시 undefined 로 저장이 가능한지 협의 후 수정
+    createStory(StoryObject.id, StoryObject.status, 1, StoryObject.name, 1);
+    // createStory(StoryObject.id, StoryObject.status, userState.currentProjectId as number, '', '');
   };
 
   return (

--- a/client/src/components/KanbanTodo/index.tsx
+++ b/client/src/components/KanbanTodo/index.tsx
@@ -1,26 +1,39 @@
 import React from 'react';
 import { useStoryState, useStoryDispatch } from '@/lib/hooks/useContextHooks';
+import { useUserState } from '@/lib/hooks/useContextHooks';
+import { createStory } from '@/lib/api/story';
 import useInput from '@/lib/hooks/useInput';
 import Styled from '@/components/KanbanTodo/style';
 import Button from '@/lib/design/Button';
 
+enum StatusType {
+  TODO,
+  IN_PRGORESS,
+  DONE,
+}
+interface StoryObject {
+  id: number;
+  name: string;
+  status: StatusType;
+}
+
 const KanbanTodo = () => {
   const storyArray = useStoryState();
   const useDispatch = useStoryDispatch();
-  const [value, onChange] = useInput();
+  const userState = useUserState();
 
+  const [value, onChange] = useInput();
   const lastStoryId = storyArray.length > 0 ? storyArray[storyArray.length - 1]?.id : 0;
-  const newStoryObj = {
+  const StoryObject: StoryObject = {
     id: lastStoryId + 1,
     name: '',
-    status: 'todo',
+    status: 'TODO',
   };
+  console.log(userState);
 
   const addStory = () => {
-    useDispatch({
-      type: 'ADD_STORY',
-      story: newStoryObj,
-    });
+    useDispatch({ type: 'ADD_STORY', story: StoryObject });
+    createStory(StoryObject.id, StoryObject.status, userState.currentProjectId as number, '', '');
   };
 
   return (

--- a/client/src/components/KanbanTodo/index.tsx
+++ b/client/src/components/KanbanTodo/index.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { useStoryState, useStoryDispatch } from '@/lib/hooks/useContextHooks';
-import { createStory } from '@/lib/api/story';
+import { createStory, getAllStories } from '@/lib/api/story';
 import useInput from '@/lib/hooks/useInput';
 import Styled from '@/components/KanbanTodo/style';
 import Button from '@/lib/design/Button';
+import { Story } from '@/contexts/storyContext';
 
 type StatusType = 'TODO' | 'IN_PROGRESS' | 'DONE';
 interface StoryObject {
@@ -33,7 +34,13 @@ const KanbanTodo = () => {
     createStory(StoryObject.id, StoryObject.status, 1, StoryObject.name, 1);
     // createStory(StoryObject.id, StoryObject.status, userState.currentProjectId as number, '', '');
   };
-
+  React.useEffect(() => {
+    (async () => {
+      //todo user의CurrentProjectId 가 없다면 Early Return, ProjectID 로 조회하게함
+      const stories = await getAllStories(1);
+      stories.forEach((story: Story) => useDispatch({ type: `ADD_STORY`, story }));
+    })();
+  }, []);
   return (
     <Styled.Column>
       <h4>To do</h4>

--- a/client/src/components/KanbanTodo/index.tsx
+++ b/client/src/components/KanbanTodo/index.tsx
@@ -4,8 +4,6 @@ import useInput from '@/lib/hooks/useInput';
 import Styled from '@/components/KanbanTodo/style';
 import Button from '@/lib/design/Button';
 
-type StatusType = 'todo' | 'progress' | 'done';
-
 const KanbanTodo = () => {
   const storyArray = useStoryState();
   const useDispatch = useStoryDispatch();

--- a/client/src/contexts/storyContext.tsx
+++ b/client/src/contexts/storyContext.tsx
@@ -1,16 +1,12 @@
 import React, { createContext, Dispatch, useReducer } from 'react';
 import producer from 'immer';
 
-enum StatusType {
-  TODO,
-  IN_PRGORESS,
-  DONE,
-}
+type StatusType = 'TODO' | 'IN_PROGRESS' | 'DONE';
 
 type Story = {
   id: number;
   name: string;
-  status: StatusType;
+  status: StatusEnum;
   epicName?: string;
   epicId?: number;
 };

--- a/client/src/contexts/storyContext.tsx
+++ b/client/src/contexts/storyContext.tsx
@@ -1,10 +1,16 @@
 import React, { createContext, Dispatch, useReducer } from 'react';
 import producer from 'immer';
 
+enum StatusType {
+  TODO,
+  IN_PRGORESS,
+  DONE,
+}
+
 type Story = {
   id: number;
   name: string;
-  status: string;
+  status: StatusType;
   epicName?: string;
   epicId?: number;
 };
@@ -12,6 +18,7 @@ type Story = {
 type CreateStory = {
   id: number;
   name: string;
+  status: StatusType;
 };
 
 type UpdateStory = {

--- a/client/src/contexts/storyContext.tsx
+++ b/client/src/contexts/storyContext.tsx
@@ -3,10 +3,10 @@ import producer from 'immer';
 
 type StatusType = 'TODO' | 'IN_PROGRESS' | 'DONE';
 
-type Story = {
+export type Story = {
   id: number;
   name: string;
-  status: StatusEnum;
+  status: StatusType;
   epicName?: string;
   epicId?: number;
 };

--- a/client/src/lib/api/story.ts
+++ b/client/src/lib/api/story.ts
@@ -1,6 +1,10 @@
 import axios from 'axios';
 
-type StatusType = 'TODO' | 'IN_PRGORESS' | 'DONE';
+enum StatusType {
+  TODO,
+  IN_PRGORESS,
+  DONE,
+}
 
 const instance = axios.create({
   baseURL: process.env.SERVER_URL + '/api/storys',
@@ -8,7 +12,6 @@ const instance = axios.create({
 });
 
 /**
- *
  * @param storyId 스토리 id
  * @param storyName 스토리 이름
  * @param status 스토리의 상태
@@ -18,14 +21,16 @@ const instance = axios.create({
 export const createStory = async (
   storyId: number | string,
   status: StatusType,
+  projectId: number,
   storyName?: string,
   epicId?: number | string,
 ) => {
   try {
     const result: { data: { id: number } } = await instance.post('', {
       storyId: storyId,
-      storyName: storyName,
       status: status,
+      projectId: projectId,
+      storyName: storyName,
       epicId: epicId,
     });
     return result.data;

--- a/client/src/lib/api/story.ts
+++ b/client/src/lib/api/story.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { Story } from '@/contexts/storyContext';
 
 type StatusType = 'TODO' | 'IN_PROGRESS' | 'DONE';
 
@@ -7,10 +8,20 @@ const instance = axios.create({
   withCredentials: true,
 });
 
+export const getAllStories = async (projectId: number | string) => {
+  try {
+    const result: { data: Story[] } = await instance.get(`?projectId=${projectId}`);
+    return result.data;
+  } catch (e) {
+    console.error('[FAIL] 스토리 조회 실패');
+    throw e;
+  }
+};
 /**
  * @param storyId 스토리 id
- * @param storyName 스토리 이름
  * @param status 스토리의 상태
+ * @param projectId 프로젝트 id
+ * @param storyName 스토리 이름
  * @param epicId 에픽 id
  * @returns id 를 프로퍼티로 가지는 객체, 스토리 생성 성공시 생성된 스토리의 id, 실패시 -1값 { id: number }
  */
@@ -21,7 +32,6 @@ export const createStory = async (
   storyName?: string,
   epicId?: number | string,
 ) => {
-  console.log(storyId, status, projectId, storyName, epicId);
   try {
     const result: { data: { id: number } } = await instance.post('', {
       storyId: storyId,

--- a/client/src/lib/api/story.ts
+++ b/client/src/lib/api/story.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-type StatusType = 'todo' | 'progress' | 'done';
+type StatusType = 'TODO' | 'IN_PRGORESS' | 'DONE';
 
 const instance = axios.create({
   baseURL: process.env.SERVER_URL + '/api/storys',

--- a/client/src/lib/api/story.ts
+++ b/client/src/lib/api/story.ts
@@ -1,13 +1,9 @@
 import axios from 'axios';
 
-enum StatusType {
-  TODO,
-  IN_PRGORESS,
-  DONE,
-}
+type StatusType = 'TODO' | 'IN_PROGRESS' | 'DONE';
 
 const instance = axios.create({
-  baseURL: process.env.SERVER_URL + '/api/storys',
+  baseURL: process.env.SERVER_URL + '/api/stories',
   withCredentials: true,
 });
 
@@ -25,6 +21,7 @@ export const createStory = async (
   storyName?: string,
   epicId?: number | string,
 ) => {
+  console.log(storyId, status, projectId, storyName, epicId);
   try {
     const result: { data: { id: number } } = await instance.post('', {
       storyId: storyId,

--- a/server/src/Stories/Stories.controller.ts
+++ b/server/src/Stories/Stories.controller.ts
@@ -22,6 +22,7 @@ export const getAllStoriesByProject = async (req: Request, res: Response) => {
     }));
     res.status(200).json(storiesWithEpicName);
   } catch (e) {
+    console.log(e);
     const result = (e as Error).message;
     if (result === 'query is not vaild') {
       res.status(400).json(result);
@@ -35,7 +36,7 @@ export const getAllStoriesByProject = async (req: Request, res: Response) => {
  * @body name: string 새롭게 생성하는 에픽의 이름
  * @response id: number 새롭게 생성된 에픽의 id값
  */
-export const createStory = async (req: Request, res: Response) => {
+export const postStory = async (req: Request, res: Response) => {
   try {
     const result = await getRepository(Stories)
       .createQueryBuilder()
@@ -44,8 +45,8 @@ export const createStory = async (req: Request, res: Response) => {
       .values({
         id: req.body.storyId,
         name: req.body.storyName,
-        status: req.body.status,
-        epics: req.body.epicId,
+        projects: () => req.body.projectId,
+        epics: () => req.body.epicId,
       })
       .execute();
     res.status(201).json({ id: result.raw.insertId });

--- a/server/src/Stories/Stories.controller.ts
+++ b/server/src/Stories/Stories.controller.ts
@@ -8,18 +8,21 @@ export const getAllStoriesByProject = async (req: Request, res: Response) => {
     if (!queryValidator(req.query, ['projectId'])) {
       throw new Error('query is not vaild');
     }
+
     const { projectId } = req.query;
     const storyRepository = getRepository(Stories);
     const stories = await storyRepository.find({
       relations: ['projects', 'epics'],
-      where: { projects: { name: +(projectId as string) } },
+      where: { projects: { id: +(projectId as string) } },
     });
+
     const storiesWithEpicName = stories.map((el) => ({
       id: el.id,
       name: el.name,
       status: el.status,
       epic: el.epics.name,
     }));
+
     res.status(200).json(storiesWithEpicName);
   } catch (e) {
     console.log(e);

--- a/server/src/Stories/Stories.router.ts
+++ b/server/src/Stories/Stories.router.ts
@@ -1,10 +1,11 @@
 import express from 'express';
 import cors from 'cors';
 import options from '../../lib/config/corsConfig';
-import { getAllStoriesByProject } from './Stories.controller';
+import { getAllStoriesByProject, postStory } from './Stories.controller';
 
 const router = express.Router();
 
 router.get('/', cors(options), getAllStoriesByProject);
+router.post('/', cors(options), postStory);
 
 export default router;


### PR DESCRIPTION
## 😀 제목

Post 요청을 통해 스토리 아이템을 추가할 수 있으며, 기존 스토리 아이템을 가져올 수 있다

## ⛅️ 내용

> 이 PR의 작업 요약

- Post 요청을 통해 Story 아이템을 추가 할 수 있다.
- 칸반 페이지를 클릭 시에 ProjectID 기반으로 Get 요청을 통해 스토리를 가져온다.

## 🎸특이사항

> 리뷰시 참고할만한 내용, 주의깊게 봐줬으면 하는 내용

- 찬호님이 작성해주셨던 프로젝트 네임 기반으로 조회했던 스토리 조회함수를 프로젝트 아이디 기반으로 변경했습니다.
- 제가 ENUM Type 에 대해서 잘 모르는 것 같아서 내일 여쭤볼게요!
- 지금은 User 의 ProjectID 를 1 로 하드코딩해서 넣어줬는데, 이 부분은 현민님이 고민했던 부분과 유사한 것 같습니다. 이 부분도 같이 이야기하면 좋을 것 같아요 :) 
- 