### PR TITLE
메인페이지 리스트뷰 구현

### DIFF
--- a/client/src/components/ListViewLayer/ListView/index.tsx
+++ b/client/src/components/ListViewLayer/ListView/index.tsx
@@ -10,7 +10,7 @@ const ListView = () => {
   const privateTasks = state.privateTasks;
   const projectTasks = state.projectTasks;
   const allTasks = [...privateTasks!, ...projectTasks!];
-  console.log(allTasks);
+
   return (
     <Styled.Container>
       <ListViewHeader />

--- a/client/src/components/ListViewLayer/ListView/index.tsx
+++ b/client/src/components/ListViewLayer/ListView/index.tsx
@@ -3,11 +3,15 @@ import Styled from '@/components/ListViewLayer/ListView/style';
 import { useUserState } from '@/lib/hooks/useContextHooks';
 import ListViewHeader from '@/components/ListViewLayer/ListViewHeader';
 import ListViewItem from '@/components/ListViewLayer/ListViewItem';
-import { PrivateTask, ProjectTask } from '@/contexts/userContext';
+import { PrivateTask, ProjectType } from '@/contexts/userContext';
 
 export type ListState = 'all' | 'private' | 'project' | 'done';
 
-type AllTasks = (PrivateTask | ProjectTask)[];
+export interface TaskProp extends PrivateTask {
+  project?: ProjectType;
+}
+
+type AllTasks = TaskProp[];
 
 const ListView = () => {
   const userState = useUserState();
@@ -28,9 +32,11 @@ const ListView = () => {
   return (
     <Styled.Container>
       <ListViewHeader listState={listState} handleListState={handleListState} />
-      {allTasks.map((task, i) => (
-        <ListViewItem task={task} key={'' + i + task.id} />
-      ))}
+      <Styled.ItemWrapper>
+        {allTasks.map((task, i) => (
+          <ListViewItem task={task} key={'' + i + task.id} />
+        ))}
+      </Styled.ItemWrapper>
     </Styled.Container>
   );
 };

--- a/client/src/components/ListViewLayer/ListView/index.tsx
+++ b/client/src/components/ListViewLayer/ListView/index.tsx
@@ -1,21 +1,35 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Styled from '@/components/ListViewLayer/ListView/style';
-import { useUserDispatch, useUserState } from '@/lib/hooks/useContextHooks';
+import { useUserState } from '@/lib/hooks/useContextHooks';
 import ListViewHeader from '@/components/ListViewLayer/ListViewHeader';
 import ListViewItem from '@/components/ListViewLayer/ListViewItem';
+import { PrivateTask, ProjectTask } from '@/contexts/userContext';
+
+export type ListState = 'all' | 'private' | 'project' | 'done';
+
+type AllTasks = (PrivateTask | ProjectTask)[];
 
 const ListView = () => {
-  const state = useUserState();
-  const dispatch = useUserDispatch();
-  const privateTasks = state.privateTasks;
-  const projectTasks = state.projectTasks;
-  const allTasks = [...privateTasks!, ...projectTasks!];
+  const userState = useUserState();
+  const privateTasks = userState.privateTasks;
+  const projectTasks = userState.projectTasks;
+  const allTasks: AllTasks = [...privateTasks!, ...projectTasks!].sort((a, b) =>
+    a.updatedAt < b.updatedAt ? 1 : -1,
+  );
+
+  const [listState, setListState] = useState<ListState>('all');
+
+  const handleListState = (event: React.MouseEvent) => {
+    const target = event.target as HTMLElement;
+    if (!target.id) return;
+    setListState(target.id as ListState);
+  };
 
   return (
     <Styled.Container>
-      <ListViewHeader />
-      {allTasks.map((item, i) => (
-        <ListViewItem item={item.name} key={i} />
+      <ListViewHeader listState={listState} handleListState={handleListState} />
+      {allTasks.map((task, i) => (
+        <ListViewItem task={task} key={'' + i + task.id} />
       ))}
     </Styled.Container>
   );

--- a/client/src/components/ListViewLayer/ListView/style.ts
+++ b/client/src/components/ListViewLayer/ListView/style.ts
@@ -2,16 +2,17 @@ import styled from 'styled-components';
 
 const Styled = {
   Container: styled.section`
-    display: flex;
-    flex-direction: column;
-
     width: 753px;
-    height: 650px;
+    height: 680px;
 
     padding: 15px 30px;
 
     border-radius: 8px;
     background-color: ${({ theme }) => theme.color.gray100};
+  `,
+  ItemWrapper: styled.ul`
+    height: 550px;
+    margin-top: 90px;
 
     overflow-y: scroll;
     &::-webkit-scrollbar {

--- a/client/src/components/ListViewLayer/ListViewHeader/index.tsx
+++ b/client/src/components/ListViewLayer/ListViewHeader/index.tsx
@@ -1,16 +1,13 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Styled from '@/components/ListViewLayer/ListViewHeader/style';
+import { ListState } from '../ListView';
 
-type ListState = 'all' | 'private' | 'project' | 'done';
+type ListProps = {
+  listState: ListState;
+  handleListState: (event: React.MouseEvent) => void;
+};
 
-const ListViewHeader = () => {
-  const [listState, setListState] = useState<ListState>('all');
-
-  const handleListState = (event: React.MouseEvent) => {
-    const target = event.target as HTMLElement;
-    if (!target.id) return;
-    setListState(target.id as ListState);
-  };
+const ListViewHeader = ({ listState, handleListState }: ListProps) => {
   return (
     <Styled.Container onClick={handleListState}>
       <Styled.StateButton id="all" active={'all' === listState}>

--- a/client/src/components/ListViewLayer/ListViewHeader/style.ts
+++ b/client/src/components/ListViewLayer/ListViewHeader/style.ts
@@ -6,6 +6,7 @@ interface StateButtonProps {
 
 const Styled = {
   Container: styled.header`
+    position: absolute;
     display: flex;
     align-items: center;
 

--- a/client/src/components/ListViewLayer/ListViewItem/index.tsx
+++ b/client/src/components/ListViewLayer/ListViewItem/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { PrivateTask, ProjectTask } from '@/contexts/userContext';
 
-const ListViewItem = ({ item }) => {
-  return <div>{item}</div>;
+const ListViewItem = ({ task }: { task: PrivateTask | ProjectTask }) => {
+  return <div>{task.name}</div>;
 };
 
 export default ListViewItem;

--- a/client/src/components/ListViewLayer/ListViewItem/index.tsx
+++ b/client/src/components/ListViewLayer/ListViewItem/index.tsx
@@ -1,8 +1,18 @@
 import React from 'react';
-import { PrivateTask, ProjectTask } from '@/contexts/userContext';
+import Styled from '@/components/ListViewLayer/ListViewItem/style';
+import { TaskProp } from '@/components/ListViewLayer/ListView';
+import Button from '@/lib/design/Button';
 
-const ListViewItem = ({ task }: { task: PrivateTask | ProjectTask }) => {
-  return <div>{task.name}</div>;
+const ListViewItem = ({ task }: { task: TaskProp }) => {
+  return (
+    <Styled.Container>
+      <Styled.Title>{task.project ? task.project.name : 'TODO'}</Styled.Title>
+      <Styled.Content>{task.name}</Styled.Content>
+      <Button size="small" category="default" onClick={() => console.log()}>
+        완료
+      </Button>
+    </Styled.Container>
+  );
 };
 
 export default ListViewItem;

--- a/client/src/components/ListViewLayer/ListViewItem/style.ts
+++ b/client/src/components/ListViewLayer/ListViewItem/style.ts
@@ -21,7 +21,6 @@ const Styled = {
   Title: styled.div`
     width: 120px;
     margin-right: 60px;
-    font-weight: 600;
 
     overflow-x: hidden;
   `,

--- a/client/src/components/ListViewLayer/ListViewItem/style.ts
+++ b/client/src/components/ListViewLayer/ListViewItem/style.ts
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+
+const Styled = {
+  Container: styled.li`
+    display: flex;
+    align-items: center;
+
+    height: 69px;
+    padding: 0 20px;
+    margin-bottom: 5px;
+
+    border-radius: 8px;
+    background-color: white;
+
+    font: ${({ theme }) => theme.font.body_regular};
+
+    &:hover {
+      background-color: ${({ theme }) => theme.color.gray100};
+    }
+  `,
+  Title: styled.div`
+    width: 120px;
+    margin-right: 60px;
+    font-weight: 600;
+
+    overflow-x: hidden;
+  `,
+  Content: styled.div`
+    width: 350px;
+    margin-right: 50px;
+  `,
+};
+
+export default Styled;

--- a/client/src/components/TodoInputBar/index.tsx
+++ b/client/src/components/TodoInputBar/index.tsx
@@ -18,7 +18,8 @@ const TodoInputBar = () => {
       buttonDisableHandler(true);
     }
   };
-  const clickHandler = async () => {
+  const submitHandler = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     if (typeof userState.id === 'number') {
       const target = todoInput.current as HTMLInputElement;
       const todo = await createTodo(target.value, userState.id);
@@ -31,9 +32,16 @@ const TodoInputBar = () => {
   };
 
   return (
-    <S.TodoInputBarContainer>
+    <S.TodoInputBarContainer onSubmit={submitHandler}>
       <S.InputBox ref={todoInput} placeholder="할 일을 입력하세요." onChange={inputHandler} />
-      <Button category="cancel" size="small" onClick={clickHandler} disabled={buttonDisabled}>
+      <Button
+        category="cancel"
+        size="small"
+        onClick={() => {
+          return;
+        }}
+        disabled={buttonDisabled}
+      >
         {'할 일 추가하기'}
       </Button>
     </S.TodoInputBarContainer>

--- a/client/src/components/TodoInputBar/index.tsx
+++ b/client/src/components/TodoInputBar/index.tsx
@@ -1,11 +1,13 @@
 import React, { ChangeEvent, useRef, useState } from 'react';
 import * as S from './style';
 import Button from '@/lib/design/Button';
-import { useUserState } from '@/lib/hooks/useContextHooks';
+import { useUserDispatch, useUserState } from '@/lib/hooks/useContextHooks';
 import { createTodo } from '@/lib/api/todo';
 
 const TodoInputBar = () => {
-  const state = useUserState();
+  const userState = useUserState();
+  const userDispatch = useUserDispatch();
+
   const [buttonDisabled, buttonDisableHandler] = useState(true);
   const todoInput = useRef<HTMLInputElement>(null);
   const inputHandler = (e: ChangeEvent<HTMLInputElement>) => {
@@ -16,11 +18,13 @@ const TodoInputBar = () => {
       buttonDisableHandler(true);
     }
   };
-  const clickHandler = () => {
-    if (typeof state.id === 'number') {
+  const clickHandler = async () => {
+    if (typeof userState.id === 'number') {
       const target = todoInput.current as HTMLInputElement;
-      const todo = createTodo(target.value, state.id);
-      // to-do user의 task에 todo 결과 넣기
+      const todo = await createTodo(target.value, userState.id);
+      if (todo) {
+        userDispatch({ type: 'ADD_PRIVATE_TASK', payload: todo });
+      }
       target.value = '';
       buttonDisableHandler(true);
     }

--- a/client/src/components/TodoInputBar/style.ts
+++ b/client/src/components/TodoInputBar/style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const TodoInputBarContainer = styled.div`
+const TodoInputBarContainer = styled.form`
   width: 753px;
   height: 80px;
 

--- a/client/src/components/TodoInputBar/style.ts
+++ b/client/src/components/TodoInputBar/style.ts
@@ -8,7 +8,6 @@ const TodoInputBarContainer = styled.div`
   flex-direction: row;
   justify-content: space-around;
   align-items: center;
-  margin-top: 60px;
   margin-bottom: 20px;
 
   border-radius: 8px;

--- a/client/src/contexts/userContext.tsx
+++ b/client/src/contexts/userContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, Dispatch, useReducer } from 'react';
+import produce from 'immer';
 
 type ProjectType = {
   id: number;
@@ -35,7 +36,8 @@ export type UserState = {
 type UserAction =
   | { type: 'GET_USER'; payload: UserState }
   | { type: 'LOGOUT' }
-  | { type: 'UPDATE_USER'; payload: UserState };
+  | { type: 'UPDATE_USER'; payload: UserState }
+  | { type: 'ADD_PRIVATE_TASK'; payload: PrivateTask };
 
 type ContextType = {
   userState: UserState | null;
@@ -45,7 +47,7 @@ type ContextType = {
 const reducer = (state: UserState, action: UserAction): UserState => {
   switch (action.type) {
     case 'GET_USER':
-      if (action.payload.projects && action.payload.projects.length !== 0) {
+      if (action.payload.projects?.length) {
         return {
           currentProjectId: action.payload.projects[0].id,
           currentProjectName: action.payload.projects[0].name,
@@ -59,8 +61,14 @@ const reducer = (state: UserState, action: UserAction): UserState => {
 
     case 'LOGOUT':
       return {};
+
     case 'UPDATE_USER':
       return { ...state, ...action.payload };
+
+    case 'ADD_PRIVATE_TASK':
+      return produce(state, (draft) => {
+        draft.privateTasks?.unshift(action.payload);
+      });
     default:
       return {
         ...state,

--- a/client/src/contexts/userContext.tsx
+++ b/client/src/contexts/userContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, Dispatch, useReducer } from 'react';
 import produce from 'immer';
 
-type ProjectType = {
+export type ProjectType = {
   id: number;
   name: string;
 };

--- a/client/src/contexts/userContext.tsx
+++ b/client/src/contexts/userContext.tsx
@@ -22,7 +22,7 @@ export type UserState = {
   name?: string;
   job?: string;
   email?: string;
-  url?: string;
+  imageURL?: string;
   admin?: boolean;
   organization?: number;
   currentProjectName?: string;

--- a/client/src/contexts/userContext.tsx
+++ b/client/src/contexts/userContext.tsx
@@ -6,7 +6,7 @@ type ProjectType = {
   name: string;
 };
 
-interface PrivateTask {
+export interface PrivateTask {
   id: number;
   name: string;
   status: boolean;
@@ -14,7 +14,7 @@ interface PrivateTask {
   updatedAt: string;
 }
 
-interface ProjectTask extends PrivateTask {
+export interface ProjectTask extends PrivateTask {
   project: ProjectType;
 }
 

--- a/client/src/lib/api/todo.ts
+++ b/client/src/lib/api/todo.ts
@@ -9,6 +9,8 @@ interface Todo {
   id: number;
   status: boolean;
   name: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export const createTodo = async (name: string, userId: number) => {
@@ -17,7 +19,6 @@ export const createTodo = async (name: string, userId: number) => {
       name: name,
       userId: userId,
     });
-    // 추후 로그인된이메일 확인은 세션에서 (get요청이므로 데이터 없애야함)
     return result.data;
   } catch (e) {
     console.error('TODO 생성 실패');

--- a/client/src/lib/design/Button.tsx
+++ b/client/src/lib/design/Button.tsx
@@ -20,8 +20,7 @@ const StyledButton = styled.button<LayoutProps>`
   border-radius: 8px;
 
   padding: ${(props) => (props.size === 'large' ? '13px 50px' : '10px 15px')};
-  font: ${({ theme }) => theme.font.bold_regular};
-  font-size: ${(props) =>
+  font: ${(props) =>
     props.size === 'large' ? props.theme.font.bold_regular : props.theme.font.bold_small};
 
   background-color: ${(props) =>

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -23,9 +23,6 @@ const MainPage = () => {
 export default MainPage;
 
 const ContentContainer = styled.div`
-  width: 1140px;
-  height: 883px;
-
   margin-top: 60px;
   display: flex;
   flex-direction: row;

--- a/client/src/styles/GlobalStyle.ts
+++ b/client/src/styles/GlobalStyle.ts
@@ -52,6 +52,8 @@ const GlobalStyle = createGlobalStyle`
     max-width: 1140px;
     margin: 0 auto;
     
+    color: #30333E;
+    
     ::-webkit-scrollbar {
       width: 6px;
     }

--- a/server/src/Todo/Todo.controller.ts
+++ b/server/src/Todo/Todo.controller.ts
@@ -24,6 +24,8 @@ export default async function createTodo(req: Request, res: Response) {
       id: todo.id,
       status: todo.status,
       name: todo.name,
+      updatedAt: todo.updatedAt,
+      createdAt: todo.createdAt,
     });
   } catch (e) {
     const result = (e as Error).message;

--- a/server/src/Users/Users.service.ts
+++ b/server/src/Users/Users.service.ts
@@ -26,10 +26,11 @@ interface User {
   name: string;
   job: string;
   email: string;
-  url: string;
+  imageURL: string;
   admin: boolean;
   organization: number;
   projects: Array<ProjectType>;
+  org?: object;
 }
 
 export const getUserTodos = async (email: string): Promise<PrivateTask[]> => {
@@ -63,14 +64,17 @@ export const getUserTasks = async (email: string): Promise<ProjectTask[]> => {
   }));
 };
 
-export const getUserInfo = async (email: string): Promise<Users> => {
+export const getUserInfo = async (email: string): Promise<User> => {
   const userRepository = getRepository(Users);
   const user = await userRepository.findOne({
-    relations: ['projects'],
+    relations: ['projects', 'org'],
     where: { email },
   });
   if (!user) throw Error('유저 없음');
-  return user;
+
+  const result: User = { ...user, organization: user.org.id };
+  delete result.org;
+  return result;
 };
 
 export const isValidatedEmail = (email: string): boolean => {


### PR DESCRIPTION
## 😀 제목

메인페이지 리스트뷰 구현

## ⛅️ 내용

- 개인 할일 추가시 context에 반영되도록 하였습니다. (기존에는 db에만 전송하였음)
- 할일이 update 최근 순서로 표시되도록 구현하였습니다.
- 리스트 아이템이 기획대로 표현되도록 레이아웃을 구성하였습니다.
- todoInput을 기존의 div에서 form으로 변경하여 엔터를 쳐도 submit이 되도록 변경하였습니다.
- 각 상태를 바꿀때마다 리스트뷰가 업데이트 되도록 하였습니다.

## 🎸특이사항

- useMemo를 처음써봤는데 제대로 쓴건지 모르겠네요 ㅎㅎ
