### PR TITLE
리스트 뷰의 완료 삭제 버튼 구현 (context only)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 package.json
 node_modules/
 webpack.config.js
+jest.config.js

--- a/client/src/components/ListViewItem/index.tsx
+++ b/client/src/components/ListViewItem/index.tsx
@@ -3,14 +3,27 @@ import Styled from '@/components/ListViewItem/style';
 import { TaskProp } from '@/layers/ListView';
 import Button from '@/lib/design/Button';
 
-const ListViewItem = ({ task }: { task: TaskProp }) => {
+interface ListItemProp {
+  task: TaskProp;
+  onClickMethod: (task: TaskProp) => void;
+}
+
+const ListViewItem = ({ task, onClickMethod }: ListItemProp) => {
   return (
     <Styled.Container>
       <Styled.Title>{task.project ? task.project.name : 'TODO'}</Styled.Title>
       <Styled.Content>{task.name}</Styled.Content>
-      <Button size="small" category="default" onClick={() => console.log()}>
-        완료
-      </Button>
+      {!task.status ? (
+        <Button size="small" category="default" onClick={() => onClickMethod(task)}>
+          완료
+        </Button>
+      ) : (
+        !task.project && (
+          <Button size="small" category="confirm" onClick={() => onClickMethod(task)}>
+            삭제
+          </Button>
+        )
+      )}
     </Styled.Container>
   );
 };

--- a/client/src/contexts/storyContext.tsx
+++ b/client/src/contexts/storyContext.tsx
@@ -35,7 +35,7 @@ function reducer(state: StoryState, action: StoryAction): StoryState {
           return {
             ...el,
             ...action.story,
-          } as Story;
+          };
         });
       });
     case 'LOAD_STORY':

--- a/client/src/contexts/userContext.tsx
+++ b/client/src/contexts/userContext.tsx
@@ -22,7 +22,10 @@ type UserAction =
   | { type: 'GET_USER'; payload: UserState }
   | { type: 'LOGOUT' }
   | { type: 'UPDATE_USER'; payload: UserState }
-  | { type: 'ADD_PRIVATE_TASK'; payload: PrivateTask };
+  | { type: 'ADD_PRIVATE_TASK'; payload: PrivateTask }
+  | { type: 'DELETE_PRIVATE_TASK'; payload: number }
+  | { type: 'FINISH_PRIVATE_TASK'; payload: number }
+  | { type: 'FINISH_PROJECT_TASK'; payload: number };
 
 type ContextType = {
   userState: UserState | null;
@@ -54,6 +57,24 @@ const reducer = (state: UserState, action: UserAction): UserState => {
       return produce(state, (draft) => {
         draft.privateTasks?.unshift(action.payload);
       });
+
+    case 'DELETE_PRIVATE_TASK':
+      return produce(state, (draft) => {
+        draft.privateTasks = draft.privateTasks!.filter((task) => task.id !== action.payload);
+      });
+
+    case 'FINISH_PRIVATE_TASK':
+      return produce(state, (draft) => {
+        const finishedTask = draft.privateTasks!.find((task) => task.id === action.payload);
+        finishedTask!.status = true;
+      });
+
+    case 'FINISH_PROJECT_TASK':
+      return produce(state, (draft) => {
+        const finishedTask = draft.projectTasks!.find((task) => task.id === action.payload);
+        finishedTask!.status = true;
+      });
+
     default:
       return {
         ...state,

--- a/client/src/layers/ListView/index.tsx
+++ b/client/src/layers/ListView/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import Styled from '@/layers/ListView/style';
-import { useUserState } from '@/lib/hooks/useContextHooks';
+import { useUserDispatch, useUserState } from '@/lib/hooks/useContextHooks';
 import ListViewHeader from '@/components/ListViewHeader';
 import ListViewItem from '@/components/ListViewItem';
 import { PrivateTask } from '@/types/task';
@@ -16,6 +16,7 @@ type AllTasks = TaskProp[];
 
 const ListView = () => {
   const userState = useUserState();
+  const userDispatch = useUserDispatch();
   const [listState, setListState] = useState<ListState>('all');
   const allTasks: AllTasks = useMemo(
     () =>
@@ -30,6 +31,19 @@ const ListView = () => {
     const target = event.target as HTMLElement;
     if (!target.id) return;
     setListState(target.id as ListState);
+  };
+
+  const onClickFinish = (task: TaskProp) => {
+    if (task.project) {
+      userDispatch({ type: 'FINISH_PROJECT_TASK', payload: task.id });
+    } else {
+      userDispatch({ type: 'FINISH_PRIVATE_TASK', payload: task.id });
+    }
+  };
+
+  const onClickDelete = (task: TaskProp) => {
+    if (task.project) return;
+    userDispatch({ type: 'DELETE_PRIVATE_TASK', payload: task.id });
   };
 
   useEffect(() => {
@@ -49,7 +63,11 @@ const ListView = () => {
       <ListViewHeader listState={listState} handleListState={handleListState} />
       <Styled.ItemWrapper>
         {renderTasks.map((task, i) => (
-          <ListViewItem task={task} key={'' + i + task.id} />
+          <ListViewItem
+            task={task}
+            key={'' + i + task.id}
+            onClickMethod={listState === 'done' ? onClickDelete : onClickFinish}
+          />
         ))}
       </Styled.ItemWrapper>
     </Styled.Container>

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "dev:client" : "yarn workspace client dev",
     "dev:server" : "yarn workspace server dev",
     "build:client" : "yarn workspace client build",
+    "test:server": "yarn workspace server test",
+    "test:client" : "yarn workspace client test",
     "ci": "echo 'hello' && yarn install --frozen-lockfile",
     "lint": "eslint ./"
   },

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testRegex: '\\.test\\.ts$',
+};

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "dev": "ts-node-dev --inspect --watch -- ./bin/www.ts"
+    "dev": "ts-node-dev --inspect --watch -- ./bin/www.ts",
+    "test": "jest --setupFiles dotenv/config --forceExit --detectOpenHandles"
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.2",
@@ -12,6 +13,7 @@
     "@types/express": "^4.17.13",
     "@types/http-errors": "^1.8.1",
     "@types/morgan": "^1.9.3",
+    "ts-jest": "^27.0.7",
     "ts-node-dev": "^1.1.8"
   },
   "dependencies": {

--- a/server/src/Users/Users.controller.ts
+++ b/server/src/Users/Users.controller.ts
@@ -21,7 +21,8 @@ export const handleGet = async (req: Request, res: Response, next: NextFunction)
       projectTasks: tasks,
     });
   } catch (err) {
-    res.status(400).json({ message: '유저 정보 없음' });
+    const result = (err as Error).message;
+    res.status(400).json({ result });
     next(err);
   }
 };

--- a/server/test/Users.test.ts
+++ b/server/test/Users.test.ts
@@ -1,0 +1,43 @@
+import { ConnectionOptions, createConnection, getConnection } from 'typeorm';
+import { entities } from '../src/index';
+import { getUserInfo } from '../src/Users/Users.service';
+
+beforeAll(async () => {
+  const dbConfig = {
+    host: process.env.DB_HOST,
+    username: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_DATABASE,
+  };
+
+  const connectionOptions: ConnectionOptions = {
+    type: 'mysql',
+    synchronize: false,
+    entities: entities,
+    ...dbConfig,
+  };
+
+  await createConnection(connectionOptions);
+});
+
+afterAll(() => {
+  getConnection().close();
+});
+
+describe('get User Info', () => {
+  it('관리자 계정', async () => {
+    const user = await getUserInfo('test1@gmail.com');
+    expect(user.admin).toBeTruthy();
+  });
+  it('사용자 계정', async () => {
+    const user = await getUserInfo('test2@gmail.com');
+    expect(user.admin).toBeFalsy();
+  });
+  // it('없는 계정', async () => {
+  //   try {
+  //     await getUserInfo('test3@gmail.com');
+  //   } catch (error) {
+  //     expect(error).toEqual({ error: '유저 없음' });
+  //   }
+  // });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4355,6 +4355,13 @@ browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^4.17.5:
     node-releases "^2.0.1"
     picocolors "^1.0.0"
 
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -5201,6 +5208,20 @@ css-loader@^3.6.0:
     postcss-value-parser "^4.1.0"
     schema-utils "^2.7.0"
     semver "^6.3.0"
+
+css-loader@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.5.1.tgz#0c43d4fbe0d97f699c91e9818cb585759091d1b1"
+  integrity sha512-gEy2w9AnJNnD9Kuo4XAP9VflW/ujKoS9c/syO+uWMlm5igc7LysKzPXaDoR2vroROkSwsTS2tGr1yGGEbZOYZQ==
+  dependencies:
+    icss-utils "^5.1.0"
+    postcss "^8.2.15"
+    postcss-modules-extract-imports "^3.0.0"
+    postcss-modules-local-by-default "^4.0.0"
+    postcss-modules-scope "^3.0.0"
+    postcss-modules-values "^4.0.0"
+    postcss-value-parser "^4.1.0"
+    semver "^7.3.5"
 
 css-select-base-adapter@^0.1.1:
   version "0.1.1"
@@ -6402,7 +6423,7 @@ fast-json-parse@^1.0.3:
   resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
   integrity sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -7458,6 +7479,11 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
+icss-utils@^5.0.0, icss-utils@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
+  integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
+
 ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
@@ -8510,7 +8536,7 @@ jest-util@^26.6.2:
     is-ci "^2.0.0"
     micromatch "^4.0.2"
 
-jest-util@^27.3.1:
+jest-util@^27.0.0, jest-util@^27.3.1:
   version "27.3.1"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.3.1.tgz#a58cdc7b6c8a560caac9ed6bdfc4e4ff23f80429"
   integrity sha512-8fg+ifEH3GDryLQf/eKZck1DEs2YuVPBCMOaHQxVVLmQwl/CDhWzrvChTX4efLZxGrw+AA0mSXv78cyytBt/uw==
@@ -8662,19 +8688,19 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
+json5@2.x, json5@^2.1.2, json5@^2.1.3:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
+  dependencies:
+    minimist "^1.2.5"
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
-
-json5@^2.1.2, json5@^2.1.3:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
-  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
-  dependencies:
-    minimist "^1.2.5"
 
 jsonfile@^2.1.0:
   version "2.4.0"
@@ -8847,6 +8873,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.memoize@4.x:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -8931,7 +8962,7 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@^1.1.1:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -9361,6 +9392,11 @@ nan@^2.12.1:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
+
+nanoid@^3.1.30:
+  version "3.1.30"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
+  integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -10162,6 +10198,11 @@ postcss-modules-extract-imports@^2.0.0:
   dependencies:
     postcss "^7.0.5"
 
+postcss-modules-extract-imports@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz#cda1f047c0ae80c97dbe28c3e76a43b88025741d"
+  integrity sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==
+
 postcss-modules-local-by-default@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz#bb14e0cc78279d504dbdcbfd7e0ca28993ffbbb0"
@@ -10169,6 +10210,15 @@ postcss-modules-local-by-default@^3.0.2:
   dependencies:
     icss-utils "^4.1.1"
     postcss "^7.0.32"
+    postcss-selector-parser "^6.0.2"
+    postcss-value-parser "^4.1.0"
+
+postcss-modules-local-by-default@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz#ebbb54fae1598eecfdf691a02b3ff3b390a5a51c"
+  integrity sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==
+  dependencies:
+    icss-utils "^5.0.0"
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.1.0"
 
@@ -10180,6 +10230,13 @@ postcss-modules-scope@^2.2.0:
     postcss "^7.0.6"
     postcss-selector-parser "^6.0.0"
 
+postcss-modules-scope@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz#9ef3151456d3bbfa120ca44898dfca6f2fa01f06"
+  integrity sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==
+  dependencies:
+    postcss-selector-parser "^6.0.4"
+
 postcss-modules-values@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz#5b5000d6ebae29b4255301b4a3a54574423e7f10"
@@ -10188,7 +10245,14 @@ postcss-modules-values@^3.0.0:
     icss-utils "^4.0.0"
     postcss "^7.0.6"
 
-postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
+postcss-modules-values@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz#d7c5e7e68c3bb3c9b27cbf48ca0bb3ffb4602c9c"
+  integrity sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==
+  dependencies:
+    icss-utils "^5.0.0"
+
+postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz#2c5bba8174ac2f6981ab631a42ab0ee54af332ea"
   integrity sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==
@@ -10208,6 +10272,15 @@ postcss@^7.0.14, postcss@^7.0.26, postcss@^7.0.32, postcss@^7.0.36, postcss@^7.0
   dependencies:
     picocolors "^0.2.1"
     source-map "^0.6.1"
+
+postcss@^8.2.15:
+  version "8.3.11"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.11.tgz#c3beca7ea811cd5e1c4a3ec6d2e7599ef1f8f858"
+  integrity sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==
+  dependencies:
+    nanoid "^3.1.30"
+    picocolors "^1.0.0"
+    source-map-js "^0.6.2"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -10707,6 +10780,13 @@ react-textarea-autosize@^8.3.0:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
+
+react-toastify@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-8.1.0.tgz#acaca4e8c4415c8474562dd84a14e6f390ed7f17"
+  integrity sha512-M+Q3rTmEw/53Csr7NsV/YnldJe4c7uERcY7Tma9mvLU98QT2VhIkKwjBzzxZkJRk/oBKyUAtkyMjMgO00hx6gQ==
+  dependencies:
+    clsx "^1.1.1"
 
 react@^17.0.2:
   version "17.0.2"
@@ -11222,17 +11302,17 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 send@0.17.1:
   version "0.17.1"
@@ -11515,6 +11595,11 @@ source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
+
+source-map-js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
+  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
 
 source-map-resolve@^0.5.0:
   version "0.5.3"
@@ -11891,6 +11976,11 @@ style-loader@^1.3.0:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^2.7.0"
+
+style-loader@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.1.tgz#057dfa6b3d4d7c7064462830f9113ed417d38575"
+  integrity sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==
 
 style-to-object@0.3.0, style-to-object@^0.3.0:
   version "0.3.0"
@@ -12277,6 +12367,20 @@ ts-essentials@^2.0.3:
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
   integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
+
+ts-jest@^27.0.7:
+  version "27.0.7"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.0.7.tgz#fb7c8c8cb5526ab371bc1b23d06e745652cca2d0"
+  integrity sha512-O41shibMqzdafpuP+CkrOL7ykbmLh+FqQrXEmV9CydQ5JBk0Sj0uAEF5TNNe94fZWKm3yYvWa/IbyV4Yg1zK2Q==
+  dependencies:
+    bs-logger "0.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^27.0.0"
+    json5 "2.x"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    semver "7.x"
+    yargs-parser "20.x"
 
 ts-node-dev@^1.1.8:
   version "1.1.8"
@@ -13254,7 +13358,7 @@ yargonaut@^1.1.4:
     figlet "^1.1.1"
     parent-require "^1.0.0"
 
-yargs-parser@^20.2.2, yargs-parser@^20.2.7:
+yargs-parser@20.x, yargs-parser@^20.2.2, yargs-parser@^20.2.7:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==


### PR DESCRIPTION
## 😀 제목

리스트 뷰의 완료 삭제 버튼 구현 (context only)

## ⛅️ 내용

- 주말에 작성해뒀던 user info 서비스로직 테스트 코드를 추가해뒀습니다. (에러 테스트는 문제가 있어서 주석처리해뒀습니다.)
- `userContext`의 액션에 할일 완료 및 삭제를 추가하였습니다.
- 리스트 뷰의 리스트 아이템 버튼에 각 상황에 맞는 액션을 연결하였습니다.
- 프로젝트의 경우 삭제버튼이 뜨지 않도록 하였습니다.

## 🎸특이사항

- 찬호님과 아까 백엔드 테스트 코드에 대해서 얘기를 나눴습니다. user 를 제외하곤 서비스와 컨트롤러 코드가 분리된 것이 없을 뿐더러 분리할 정도의 양이 아니었습니다. 그래서 테스트 코드도 컨트롤러를 테스트하여 유저와의 인터랙션을 테스트하는게 좋겠다는 의견이 나왔었습니다. 제 테스트코드는 typeOrm을 이용하여 서비스로직이 잘 이루어지는지를 테스트하는데, 이것도 이후에 컨트롤러를 테스트하는 코드로 바꿔서 통일시키는게 낫겠죠??
- 액션을 버튼과 연결시키는 과정에서 에러가 많이나서 백엔드 작업을 하지 못했습니다. 아무래도 db에서 todo를 업데이트하는 로직과, task를 업데이트 하는 로직은 내일하게 될 것 같습니다. 내일 면접도 있어서 오늘까지 홈페이지를 완전히 마무리 하고싶었는데 너무 죄송하네요 🥲 면접 후에 분발하도록 하겠습니다ㅠㅠ
