### PR TITLE
프로젝트 조회 및 생성 구현

### DIFF
--- a/client/src/components/ProjectCreateForm/index.tsx
+++ b/client/src/components/ProjectCreateForm/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Styled from '@/components/ProjectCreateForm/style';
+import { Button } from '@/lib/design';
+
+interface Props {
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onSubmitNewProject: (e: React.FormEvent) => void;
+}
+
+const ProjectCreateForm = ({ onSubmitNewProject, onChange }: Props) => {
+  return (
+    <Styled.Form onSubmit={onSubmitNewProject}>
+      <Styled.Input placeholder="프로젝트 이름을 입력하세요" onChange={onChange} />
+      <Button
+        size="large"
+        category="default"
+        onClick={() => {
+          return;
+        }}
+      >
+        생성
+      </Button>
+    </Styled.Form>
+  );
+};
+
+export default ProjectCreateForm;

--- a/client/src/components/ProjectCreateForm/style.ts
+++ b/client/src/components/ProjectCreateForm/style.ts
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+const Styled = {
+  Form: styled.form`
+    display: flex;
+    align-items: center;
+
+    width: 950px;
+    height: 75px;
+    padding: 12px;
+    margin-left: 20px;
+
+    background-color: ${({ theme }) => theme.color.gray100};
+    border-radius: 8px;
+  `,
+  Input: styled.input`
+    width: 760px;
+    height: 50px;
+    margin-right: 30px;
+    padding: 16px;
+
+    border-radius: 8px;
+
+    font: ${({ theme }) => theme.font.body_regular};
+  `,
+};
+
+export default Styled;

--- a/client/src/components/SideBarDropdown/index.tsx
+++ b/client/src/components/SideBarDropdown/index.tsx
@@ -17,11 +17,10 @@ const SideBarDropDown = () => {
     if (target.tagName !== 'LI') return;
     titleStateHandler(target.innerText);
     setUserState((prev) =>
-      produce(prev, (draft) => ({
-        ...draft,
-        currentProjectName: target.innerText,
-        currentProjectId: +target.value,
-      })),
+      produce(prev, (draft) => {
+        draft.currentProjectName = target.innerText;
+        draft.currentProjectId = +target.value;
+      }),
     );
   };
   useEffect(() => {

--- a/client/src/layers/ProjectManagement/index.tsx
+++ b/client/src/layers/ProjectManagement/index.tsx
@@ -1,5 +1,40 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import userAtom from '@/recoil/user';
+import { createProject, getAllOrgProjects } from '@/lib/api/project';
+import { useInput } from '@/lib/hooks';
+import ProjectCreateForm from '@/components/ProjectCreateForm';
+import { ProjectType } from '@/types/project';
 
 export const ProjectManagement = () => {
-  return <div>프로젝트 관리 페이지</div>;
+  const userState = useRecoilValue(userAtom);
+  const [projectList, setProjectList] = useState<ProjectType[]>([]);
+  const { value, onChange } = useInput('');
+
+  const onSubmitNewProject = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!value.length) return;
+    const newProject = await createProject(value, userState.id as number);
+  };
+
+  useEffect(() => {
+    (async () => {
+      const projects = await getAllOrgProjects(userState.organization!);
+      if (!projects) return;
+      console.log(projects);
+      setProjectList([...projects]);
+    })();
+  }, [userState.organization]);
+
+  return (
+    <>
+      <ProjectCreateForm onSubmitNewProject={onSubmitNewProject} onChange={onChange} />
+      {projectList.map((project, index) => {
+        <div key={index}>
+          <div>test</div>
+          <div>{project.name}</div>;
+        </div>;
+      })}
+    </>
+  );
 };

--- a/client/src/layers/ProjectManagement/index.tsx
+++ b/client/src/layers/ProjectManagement/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
+import produce from 'immer';
 import userAtom from '@/recoil/user';
 import { createProject, getAllOrgProjects } from '@/lib/api/project';
 import { useInput } from '@/lib/hooks';
@@ -15,6 +16,12 @@ export const ProjectManagement = () => {
     e.preventDefault();
     if (!value.length) return;
     const newProject = await createProject(value, userState.id as number);
+    if (!newProject) return;
+    setProjectList((prev) =>
+      produce(prev, (draft) => {
+        draft.push(newProject);
+      }),
+    );
   };
 
   useEffect(() => {

--- a/client/src/layers/ProjectManagement/index.tsx
+++ b/client/src/layers/ProjectManagement/index.tsx
@@ -18,23 +18,22 @@ export const ProjectManagement = () => {
   };
 
   useEffect(() => {
-    (async () => {
+    const updateProjectList = async () => {
       const projects = await getAllOrgProjects(userState.organization!);
       if (!projects) return;
-      console.log(projects);
       setProjectList([...projects]);
-    })();
+    };
+    updateProjectList();
   }, [userState.organization]);
 
   return (
-    <>
+    <div>
       <ProjectCreateForm onSubmitNewProject={onSubmitNewProject} onChange={onChange} />
-      {projectList.map((project, index) => {
+      {projectList.map((project, index) => (
         <div key={index}>
-          <div>test</div>
-          <div>{project.name}</div>;
-        </div>;
-      })}
-    </>
+          <div style={{ fontSize: 20 }}>{project.name}</div>
+        </div>
+      ))}
+    </div>
   );
 };

--- a/client/src/lib/api/project.ts
+++ b/client/src/lib/api/project.ts
@@ -15,7 +15,7 @@ interface Project {
 export const getAllProjects = async (userId: number, organizationId: number) => {
   try {
     const result = await instance.get(`/?userId=${userId}&organizationId=${organizationId}`);
-    if (result.status >= 400) throw Error();
+    if (result.status >= 400) throw new Error();
     return result.data;
   } catch (e) {
     toast.error(errorMessage.GET_PROJECT);
@@ -25,9 +25,19 @@ export const getAllProjects = async (userId: number, organizationId: number) => 
 export const createProject = async (name: string, userId: number) => {
   try {
     const newProject = await instance.post('/', { name, userId });
-    if (newProject.status >= 400) throw Error();
+    if (newProject.status >= 400) throw new Error();
     return newProject.data;
   } catch (error) {
     toast.error(errorMessage.CREATE_PROJECT);
+  }
+};
+
+export const getAllOrgProjects = async (orgId: number) => {
+  try {
+    const projects: { data: Project[]; status: number } = await instance.get(`/${orgId}`);
+    if (projects.status >= 400) throw new Error();
+    return projects.data;
+  } catch (error) {
+    toast.error(errorMessage.GET_PROJECT);
   }
 };

--- a/client/src/lib/api/project.ts
+++ b/client/src/lib/api/project.ts
@@ -3,7 +3,7 @@ import { toast } from 'react-toastify';
 import { errorMessage } from '../common/message';
 
 const instance = axios.create({
-  baseURL: process.env.SERVER_URL,
+  baseURL: process.env.SERVER_URL + '/api/projects',
   withCredentials: true,
 });
 
@@ -11,15 +11,23 @@ interface Project {
   name: string;
   id: number;
 }
-// TODO: 현재 쓰이지 않는 함수
+
 export const getAllProjects = async (userId: number, organizationId: number) => {
   try {
-    const result: { data: Array<Project> } = await instance.get(
-      `/api/projects/?userId=${userId}&organizationId=${organizationId}`,
-    );
+    const result = await instance.get(`/?userId=${userId}&organizationId=${organizationId}`);
+    if (result.status >= 400) throw Error();
     return result.data;
   } catch (e) {
     toast.error(errorMessage.GET_PROJECT);
-    throw e;
+  }
+};
+
+export const createProject = async (name: string, userId: number) => {
+  try {
+    const newProject = await instance.post('/', { name, userId });
+    if (newProject.status >= 400) throw Error();
+    return newProject.data;
+  } catch (error) {
+    toast.error(errorMessage.CREATE_PROJECT);
   }
 };

--- a/client/src/lib/api/project.ts
+++ b/client/src/lib/api/project.ts
@@ -24,7 +24,10 @@ export const getAllProjects = async (userId: number, organizationId: number) => 
 
 export const createProject = async (name: string, userId: number) => {
   try {
-    const newProject = await instance.post('/', { name, userId });
+    const newProject: { data: Project; status: number } = await instance.post('/', {
+      name,
+      userId,
+    });
     if (newProject.status >= 400) throw new Error();
     return newProject.data;
   } catch (error) {

--- a/client/src/lib/common/message/error.ts
+++ b/client/src/lib/common/message/error.ts
@@ -7,6 +7,7 @@ export const GET_TASK = '테스크 정보 요청에 실패했습니다.';
 export const CREATE_EPIC = '에픽 생성에 실패했습니다.';
 export const CREATE_TODO = 'Todo 생성에 실패했습니다.';
 export const CREATE_STORY = '스토리 생성에 실패했습니다.';
+export const CREATE_PROJECT = '프로젝트 생성에 실패했습니다.';
 
 export const UPDATE_TODO = 'Todo 항목 수정에 실패했습니다.';
 export const UPDATE_TASK = 'Task 항목 수정에 실패했습니다.';
@@ -27,6 +28,7 @@ export default {
   CREATE_EPIC,
   CREATE_TODO,
   CREATE_STORY,
+  CREATE_PROJECT,
   UPDATE_TODO,
   UPDATE_TASK,
   UPDATE_STORY,

--- a/client/src/recoil/user/selector.ts
+++ b/client/src/recoil/user/selector.ts
@@ -18,7 +18,6 @@ export const privateTasksSelector = selector<PrivateTask[]>({
         : (prev) =>
             produce(prev, (draft) => {
               draft.privateTasks = [...newValue];
-              return draft;
             }),
     );
   },
@@ -38,7 +37,6 @@ export const projectTasksSelector = selector<ProjectTask[]>({
         : (prev) =>
             produce(prev, (draft) => {
               draft.projectTasks = [...newValue];
-              return draft;
             }),
     );
   },
@@ -55,27 +53,22 @@ export const allTasksSelector = selector<ProjectTask[] | PrivateTask[]>({
 
 export const privateTaskWithIdSelector = selectorFamily<PrivateTask | undefined, number>({
   key: 'privateTaskWithIdSelector',
-  get:
-    (id) =>
-    ({ get }) => {
-      const tasks = get(privateTasksSelector);
-      return tasks?.find((el) => el.id === id);
-    },
-  set:
-    (id: number) =>
-    ({ set, get }, newValue) => {
-      set(
-        privateTasksSelector,
-        newValue instanceof DefaultValue
-          ? [...get(privateTasksSelector)]
-          : (prev) =>
-              produce(prev, (draft) => {
-                const newTask = draft.find((el) => el.id === id);
-                if (!newTask) return draft;
-                newTask.name = newValue!.name;
-                newTask.status = newValue!.status;
-                return draft;
-              }),
-      );
-    },
+  get: (id) => ({ get }) => {
+    const tasks = get(privateTasksSelector);
+    return tasks?.find((el) => el.id === id);
+  },
+  set: (id: number) => ({ set, get }, newValue) => {
+    set(
+      privateTasksSelector,
+      newValue instanceof DefaultValue
+        ? [...get(privateTasksSelector)]
+        : (prev) =>
+            produce(prev, (draft) => {
+              const newTask = draft.find((el) => el.id === id);
+              if (!newTask) return;
+              newTask.name = newValue!.name;
+              newTask.status = newValue!.status;
+            }),
+    );
+  },
 });

--- a/server/src/Projects/Projects.controller.ts
+++ b/server/src/Projects/Projects.controller.ts
@@ -1,13 +1,40 @@
-import { Request, Response, NextFunction } from 'express';
-import { bodyValidator } from '../../lib/utils/requestValidator';
 import { getRepository } from 'typeorm';
+import { Request, Response } from 'express';
+import { bodyValidator } from '../../lib/utils/requestValidator';
 
 import Users from '../Users/Users.entity';
 import Projects from './Projects.entity';
+import { getUsers } from '../Users/Users.service';
 
-// TODO: User이용하여 조회
-export const getAllProjects = async (req: Request, res: Response, next: NextFunction) => {
-  return;
+const getProjects = (users: Users[]) => {
+  const result = [];
+  for (const user of users) {
+    result.push(...user.projects);
+  }
+  result.sort((a, b) => a.id - b.id);
+  // 중복 제거
+  if (result.length === 1) return result;
+  for (let i = 1; i < result.length; i++) {
+    if (result[i].id === result[i - 1].id) {
+      result[i - 1].id = 0;
+    }
+  }
+  return result.filter((project) => project.id !== 0);
+};
+
+export const getAllProjects = async (req: Request, res: Response) => {
+  try {
+    if (!req.params.id) {
+      throw new Error('params is not valid');
+    }
+    const users = await getUsers(+req.params.id);
+
+    const projects = getProjects(users);
+    res.json(projects);
+  } catch (error) {
+    const message = (error as Error).message;
+    res.status(401).json({ message });
+  }
 };
 
 export const createProject = async (req: Request, res: Response) => {

--- a/server/src/Projects/Projects.router.ts
+++ b/server/src/Projects/Projects.router.ts
@@ -1,8 +1,9 @@
 import express from 'express';
-import { getAllProjects } from './Projects.controller';
+import { createProject, getAllProjects } from './Projects.controller';
 
 const router = express.Router();
 
-router.get('/', getAllProjects);
+router.get('/:id', getAllProjects);
+router.post('/', createProject);
 
 export default router;

--- a/server/src/Users/Users.entity.ts
+++ b/server/src/Users/Users.entity.ts
@@ -45,7 +45,7 @@ export default class Users {
 
   @OneToMany(() => Tasks, (tasks) => tasks.id)
   tasks!: Tasks[];
-  @ManyToMany(() => Projects)
+  @ManyToMany(() => Projects, (projects) => projects.id)
   @JoinTable({
     name: 'USERS_PROJECTS',
     inverseJoinColumn: { name: 'PROJECT_ID', referencedColumnName: 'id' },

--- a/server/src/Users/Users.service.ts
+++ b/server/src/Users/Users.service.ts
@@ -2,36 +2,8 @@ import { getRepository } from 'typeorm';
 import Users from './Users.entity';
 import Todo from '../Todo/Todo.entity';
 import Tasks from '../Tasks/Tasks.entity';
+import { PrivateTask, ProjectTask, User } from '../../types/user';
 import Organizations from '../Organizations/Organizations.entity';
-
-interface ProjectType {
-  id: number;
-  name: string;
-}
-
-interface PrivateTask {
-  id: number;
-  name: string;
-  status: boolean;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-interface ProjectTask extends PrivateTask {
-  project: ProjectType;
-}
-
-interface User {
-  id: number;
-  name: string;
-  job: string;
-  email: string;
-  imageURL: string;
-  admin: boolean;
-  organization: number;
-  projects: Array<ProjectType>;
-  org?: object;
-}
 
 export const getUserTodos = async (email: string): Promise<PrivateTask[]> => {
   const todoRepository = getRepository(Todo);

--- a/server/src/Users/Users.service.ts
+++ b/server/src/Users/Users.service.ts
@@ -88,6 +88,7 @@ export const getUsers = async (id: number): Promise<Users[]> => {
   const organization = await organizationRepository.findOne(id);
   if (!organization) throw new Error('조직 없음');
   const users = await userRepository.find({
+    relations: ['projects'],
     where: { org: organization },
   });
   if (!users) throw Error('유저 없음');

--- a/server/types/user.d.ts
+++ b/server/types/user.d.ts
@@ -1,0 +1,28 @@
+export interface ProjectType {
+  id: number;
+  name: string;
+}
+
+export interface PrivateTask {
+  id: number;
+  name: string;
+  status: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ProjectTask extends PrivateTask {
+  project: ProjectType;
+}
+
+export interface User {
+  id: number;
+  name: string;
+  job: string;
+  email: string;
+  imageURL: string;
+  admin: boolean;
+  organization: number;
+  projects: Array<ProjectType>;
+  org?: object;
+}


### PR DESCRIPTION
## 😀 제목

프로젝트 조회 및 생성 구현

## ⛅️ 내용

> 이 PR의 작업 요약

- db에서 조직에 속한 모든 프로젝트를 조회할 수 있는 api를 구현하였습니다.
- db에 프로젝트를 추가하는 api를 구현하였습니다. n:m 관계인 유저테이블과도 연동되도록 구현하였습니다.
- 프로젝트 관리 페이지에서 프로젝트 생성 form 을 구현하였습니다. 

## 🎸특이사항

> 리뷰시 참고할만한 내용, 주의깊게 봐줬으면 하는 내용

- 저녁먹고 하얗게 불태퉜습니다... 
- ~현재 `layers/ProjectManagement` 의 useEffect에서 setProjectList 로 api에서 받아온 배열을 넣어줬는데요. 이상하게 반영이 안되네요 ㅠㅠ `project.map`으로 div와함께 화면에 보이도록했는데 아무것도 보이지 않습니다. 제가 뭘 잘못했을까요??~ 해결완료(이유 : map 뒤를 일반괄호가 아닌 중괄호로 감싸서 return이 되지 않음)
- `useInput` 커스텀 훅을 사용중인데 input을 submit을 하고 value를 초기화 하고싶습니다. 이 때는 어떻게 써야하나요???
