### PR TITLE
칸반 보드 아이템 이동 구현 

### DIFF
--- a/client/src/components/KanbanAddBtn/index.tsx
+++ b/client/src/components/KanbanAddBtn/index.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { postStory } from '@/lib/api/story';
+import { postStory, getStoryByid } from '@/lib/api/story';
 import { Button } from '@/lib/design';
 import { useStoryDispatch, useStoryState, useUserState } from '@/lib/hooks/useContextHooks';
 import { StoryType } from '@/types/story';
 
 //TODO projectID, epicId 주입 예정
 const initialItem = {
-  id: 0,
   order: 0,
   name: '',
   status: 'TODO',
@@ -15,21 +14,16 @@ const initialItem = {
 };
 
 const KanbanAddBtn = () => {
-  const userState = useUserState();
   const storyList = useStoryState();
   const dispatchStory = useStoryDispatch();
-  const listLargestOrder = storyList
-    .filter((item) => item.status === 'TODO')
-    .map((v) => Number(v.order))
-    .find((v) => v === Math.max(v));
+  const orderList = storyList.filter((item) => item.status === 'TODO').map((v) => Number(v.order));
+  const listLargestOrder = orderList.length ? Math.max(...orderList) + 1 : 0;
 
   const addStory = async () => {
-    const newStoryItem = await postStory({
-      ...initialItem,
-      order: storyList.length > 0 ? listLargestOrder : 0,
-      projectId: userState.currentProjectId,
-    });
-    dispatchStory({ type: 'ADD_STORY', story: newStoryItem as StoryType });
+    const id = await postStory({ ...initialItem, order: listLargestOrder });
+    const storyItem = await getStoryByid(id);
+    //TODO ProjectId, EpicId 를 Dispatch 함수에 작성해야함
+    dispatchStory({ type: 'ADD_STORY', story: storyItem as StoryType });
   };
 
   return (

--- a/client/src/components/KanbanAddBtn/index.tsx
+++ b/client/src/components/KanbanAddBtn/index.tsx
@@ -1,49 +1,35 @@
-import React, { useState } from 'react';
-import { createStory, updateStoryWithId } from '@/lib/api/story';
+import React from 'react';
+import { postStory } from '@/lib/api/story';
 import { Button } from '@/lib/design';
 import { useStoryDispatch, useStoryState, useUserState } from '@/lib/hooks/useContextHooks';
 import { StoryType } from '@/types/story';
 
-const extractLastID = (array: Array<StoryType>): number => {
-  if (!array?.length) return 0;
-  return Math.max(...array.map((v) => v.id));
+//TODO projectID, epicId 주입 예정
+const initialItem = {
+  id: 0,
+  order: 0,
+  name: '',
+  status: 'TODO',
+  projectId: 1,
+  epicId: 1,
 };
 
 const KanbanAddBtn = () => {
   const userState = useUserState();
   const storyList = useStoryState();
   const dispatchStory = useStoryDispatch();
-  const lastStoryId = extractLastID(storyList);
-  const todoList = storyList.filter((item) => item.status === 'TODO');
-  //Todo 수정해야함
-  const initialItem = {
-    id: lastStoryId + 1,
-    name: '',
-    status: 'TODO',
-    order: 1,
-    projectId: 1,
-    epicId: 1,
-  };
+  const listLargestOrder = storyList
+    .filter((item) => item.status === 'TODO')
+    .map((v) => Number(v.order))
+    .find((v) => v === Math.max(v));
 
   const addStory = async () => {
-    const lastTodo = todoList?.length > 0 ? todoList[todoList.length - 1] : initialItem;
-    const beforeLastTodo = todoList?.length > 1 ? todoList[todoList.length - 2] : initialItem;
-    switch (todoList.length) {
-      case 0:
-        break;
-      case 1:
-        dispatchStory({ type: 'UPDATE_STORY', story: { ...lastTodo, order: 0 } });
-        updateStoryWithId({ ...lastTodo, order: 0 });
-        break;
-      default:
-        dispatchStory({
-          type: 'UPDATE_STORY',
-          story: { ...lastTodo, order: (1 + Number(beforeLastTodo.order)) / 2 },
-        });
-        updateStoryWithId({ ...lastTodo, order: (1 + Number(beforeLastTodo.order)) / 2 });
-    }
-    dispatchStory({ type: 'ADD_STORY', story: initialItem });
-    createStory({ ...initialItem, projectId: userState.currentProjectId });
+    const newStoryItem = await postStory({
+      ...initialItem,
+      order: storyList.length > 0 ? listLargestOrder : 0,
+      projectId: userState.currentProjectId,
+    });
+    dispatchStory({ type: 'ADD_STORY', story: newStoryItem as StoryType });
   };
 
   return (

--- a/client/src/components/KanbanColumn/index.tsx
+++ b/client/src/components/KanbanColumn/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Styled from '@/components/KanbanColumn/style';
 import { KanbanItem, KanbanAddBtn } from '@/components';
-import { StatusType, KanbanType } from '@/types/story';
+import { StatusType, KanbanType, StoryType } from '@/types/story';
 import { useStoryDispatch } from '@/lib/hooks/useContextHooks';
 
 const KanbanColumn = ({
@@ -12,6 +12,7 @@ const KanbanColumn = ({
   categoryRef,
 }: KanbanType) => {
   const [isTopEnter, setTopEnter] = useState(false);
+  const dispatchStory = useStoryDispatch();
   const handleDragStart = (
     e: React.DragEvent<HTMLElement>,
     order: number,
@@ -29,12 +30,33 @@ const KanbanColumn = ({
     dragOverRef.current = order;
     const dragOverItem = storyList.find((v) => v.id === dragOverRef.current);
     // TODO immerJS 를 통해서 새로운 배열을 만들고, 이에 대해서 update 하는 함수
-    draggingRef.current = dragOverRef.current;
+    // draggingRef.current = dragOverRef.current;
+  };
+
+  console.log(storyList);
+  const handleDragDrop = (
+    e: React.DragEvent<HTMLElement>,
+    order?: number,
+    category: StatusType,
+  ) => {
+    const toBeChangeItem = storyList.find((v) => v.order === draggingRef.current);
+    const dragOverOrderList = storyList
+      .map((v) => Number(v.order))
+      .filter((v) => v >= Number(dragOverRef.current))
+      .slice(0, 2);
+    const averageOrder = dragOverOrderList.reduce((prev, cur) => prev + cur, 0) / 2;
+    if (!toBeChangeItem) return;
+    dispatchStory({ type: 'UPDATE_STORY', story: { ...toBeChangeItem, order: averageOrder } });
+    draggingRef.current = null;
     dragOverRef.current = null;
   };
 
   return (
-    <Styled.Column>
+    <Styled.Column
+      onDragEnter={() => setTopEnter((isTopEnter) => !isTopEnter)}
+      onDragLeave={() => setTopEnter(false)}
+      onDrop={() => handleDragDrop}
+    >
       <Styled.KanBanColumnTitle
         onDragEnter={() => setTopEnter((isTopEnter) => !isTopEnter)}
         onDragLeave={() => setTopEnter(false)}
@@ -48,6 +70,7 @@ const KanbanColumn = ({
           story={story}
           handleDragStart={handleDragStart}
           handleDragEnter={handleDragEnter}
+          handleDragDrop={handleDragDrop}
         />
       ))}
       {category === 'TODO' && <KanbanAddBtn />}

--- a/client/src/components/KanbanColumn/index.tsx
+++ b/client/src/components/KanbanColumn/index.tsx
@@ -1,8 +1,12 @@
 import React, { useState } from 'react';
 import Styled from '@/components/KanbanColumn/style';
 import { KanbanItem, KanbanAddBtn } from '@/components';
-import { StatusType, KanbanType } from '@/types/story';
+import { StatusType, KanbanType, dragCategoryType } from '@/types/story';
 import { useStoryDispatch } from '@/lib/hooks/useContextHooks';
+
+const isEqualCategory = (draggingCategory: dragCategoryType, dropCategory: StatusType) => {
+  return draggingCategory.current === dropCategory;
+};
 
 const KanbanColumn = ({
   category,
@@ -15,9 +19,9 @@ const KanbanColumn = ({
   const [isTopEnter, setTopEnter] = useState(false);
   const dispatchStory = useStoryDispatch();
 
-  const handleDragDrop = (category?: StatusType) => {
-    // 동일한 칼럼 내의 제일 상단에 Item 을 놓을 때
-    if (isTopEnter) {
+  const handleDragDrop = (category: StatusType) => {
+    // 동일한 칼럼 내의 최상단
+    if (isTopEnter && isEqualCategory(draggingCategory, category)) {
       const toBeChangeItem = storyList.find((v) => v.order === draggingRef.current);
       if (!toBeChangeItem) return;
       const firstnSecondItem = storyList
@@ -38,8 +42,8 @@ const KanbanColumn = ({
       return;
     }
 
-    // 동일한 컬럼 내의 Item 의 사이 또는 최하단 위치
-    if (!isTopEnter) {
+    // 동일한 컬럼 내의 Item 사이 또는 최하단
+    if (!isTopEnter && isEqualCategory(draggingCategory, category)) {
       const toBeChangeItem = storyList.find((v) => v.order === draggingRef.current);
       const dragOverOrderList = storyList
         .map((v) => Number(v.order))
@@ -63,7 +67,7 @@ const KanbanColumn = ({
         onDragOver={(e) => e.preventDefault()}
         onDragEnter={() => setTopEnter((isTopEnter) => !isTopEnter)}
         onDragLeave={() => setTopEnter(false)}
-        onDrop={() => handleDragDrop('TODO')}
+        onDrop={() => handleDragDrop(category)}
         isTopEnter={isTopEnter}
       >
         {category}

--- a/client/src/components/KanbanColumn/index.tsx
+++ b/client/src/components/KanbanColumn/index.tsx
@@ -34,10 +34,14 @@ const KanbanColumn = ({
     category: StatusType,
   ) => {
     dragOverRef.current = order;
-    const draggingItem = storyList.filter((v) => v.order === draggingRef.current)[0];
-    const dragOverItem = storyList.filter((v) => v.order === dragOverRef.current)[0];
-    dispatchStory({ type: 'UPDATE_STORY', story: { ...draggingItem, order: dragOverItem.order } });
-    dispatchStory({ type: 'UPDATE_STORY', story: { ...dragOverItem, order: draggingItem.order } });
+    // 바닥에 파란색 선이 나타나도록 작성
+    const dragOverItem = storyList.find((v) => v.id === dragOverRef.current);
+    console.log(dragOverItem);
+    // TODO immerJS 를 통해서 새로운 배열을 만들고, 이에 대해서 update 하는 함수
+    // const draggingItem = storyList.filter((v) => v.order === draggingRef.current)[0];
+    // const dragOverItem = storyList.filter((v) => v.order === dragOverRef.current)[0];
+    // dispatchStory({ type: 'UPDATE_STORY', story: { ...draggingItem, order: dragOverItem.order } });
+    // dispatchStory({ type: 'UPDATE_STORY', story: { ...dragOverItem, order: draggingItem.order } });
     draggingRef.current = dragOverRef.current;
     dragOverRef.current = null;
   };

--- a/client/src/components/KanbanColumn/index.tsx
+++ b/client/src/components/KanbanColumn/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import Styled from '@/components/KanbanColumn/style';
 import { KanbanItem, KanbanAddBtn } from '@/components';
+import { updateStoryWithId } from '@/lib/api/story';
 import { StatusType, KanbanType, dragCategoryType } from '@/types/story';
 import { useStoryDispatch, useStoryState } from '@/lib/hooks/useContextHooks';
 
@@ -22,7 +23,7 @@ const KanbanColumn = ({
     .filter((item) => item.status === category)
     .sort((a, b) => Number(a.order) - Number(b.order));
 
-  const handleDragDrop = (category: StatusType) => {
+  const handleDragDrop = async (category: StatusType) => {
     // 동일한 칼럼 내의 최상단
     if (isTopEnter && isEqualCategory(draggingCategory, category)) {
       const toBeChangeItem = filterList.find((v) => v.order === draggingRef.current);
@@ -40,6 +41,8 @@ const KanbanColumn = ({
         type: 'UPDATE_STORY',
         story: { ...firstnSecondItem[0], order: averageOrder },
       });
+      await updateStoryWithId({ ...toBeChangeItem, order: 0 });
+      await updateStoryWithId({ ...firstnSecondItem[0], order: averageOrder });
       setTopEnter((isTopEnter) => !isTopEnter);
       draggingRef.current = null;
       dragOverRef.current = null;
@@ -58,6 +61,7 @@ const KanbanColumn = ({
 
       if (!toBeChangeItem) return;
       dispatchStory({ type: 'UPDATE_STORY', story: { ...toBeChangeItem, order: avgOrderSum } });
+      await updateStoryWithId({ ...toBeChangeItem, order: avgOrderSum });
       draggingRef.current = null;
       dragOverRef.current = null;
       return;
@@ -79,6 +83,7 @@ const KanbanColumn = ({
         type: 'UPDATE_STORY',
         story: { ...toBeChangeItem, status: category, order: avgOrderSum },
       });
+      await updateStoryWithId({ ...toBeChangeItem, status: category, order: avgOrderSum });
       draggingRef.current = null;
       dragOverRef.current = null;
       return;
@@ -99,6 +104,7 @@ const KanbanColumn = ({
         type: 'UPDATE_STORY',
         story: { ...toBeChangeItem, status: category, order: 0 },
       });
+      await updateStoryWithId({ ...toBeChangeItem, status: category, order: 0 });
 
       setTopEnter((isTopEnter) => !isTopEnter);
       draggingRef.current = null;
@@ -109,7 +115,7 @@ const KanbanColumn = ({
         type: 'UPDATE_STORY',
         story: { ...firstnSecondItem[0], order: averageOrder },
       });
-
+      await updateStoryWithId({ ...firstnSecondItem[0], order: averageOrder });
       return;
     }
   };

--- a/client/src/components/KanbanColumn/index.tsx
+++ b/client/src/components/KanbanColumn/index.tsx
@@ -1,15 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Styled from '@/components/KanbanColumn/style';
 import { KanbanItem, KanbanAddBtn } from '@/components';
-import { StatusType, StoryType } from '@/types/story';
+import { StatusType, KanbanType } from '@/types/story';
 import { useStoryDispatch } from '@/lib/hooks/useContextHooks';
-interface KanbanType {
-  storyList: Array<StoryType>;
-  category: StatusType;
-  draggingRef: React.MutableRefObject<number | null>;
-  dragOverRef: React.MutableRefObject<number | null>;
-  categoryRef: React.MutableRefObject<StatusType>;
-}
 
 const KanbanColumn = ({
   category,
@@ -18,7 +11,7 @@ const KanbanColumn = ({
   dragOverRef,
   categoryRef,
 }: KanbanType) => {
-  const dispatchStory = useStoryDispatch();
+  const [isTopEnter, setTopEnter] = useState(false);
   const handleDragStart = (
     e: React.DragEvent<HTMLElement>,
     order: number,
@@ -36,19 +29,19 @@ const KanbanColumn = ({
     dragOverRef.current = order;
     // 바닥에 파란색 선이 나타나도록 작성
     const dragOverItem = storyList.find((v) => v.id === dragOverRef.current);
-    console.log(dragOverItem);
     // TODO immerJS 를 통해서 새로운 배열을 만들고, 이에 대해서 update 하는 함수
-    // const draggingItem = storyList.filter((v) => v.order === draggingRef.current)[0];
-    // const dragOverItem = storyList.filter((v) => v.order === dragOverRef.current)[0];
-    // dispatchStory({ type: 'UPDATE_STORY', story: { ...draggingItem, order: dragOverItem.order } });
-    // dispatchStory({ type: 'UPDATE_STORY', story: { ...dragOverItem, order: draggingItem.order } });
     draggingRef.current = dragOverRef.current;
     dragOverRef.current = null;
   };
 
   return (
     <Styled.Column>
-      <h4>{category}</h4>
+      <h4
+        onDragEnter={() => setTopEnter((isTopEnter) => !isTopEnter)}
+        onDragLeave={() => setTopEnter(false)}
+      >
+        {category}
+      </h4>
       {storyList?.map((story) => (
         <KanbanItem
           key={story.id}

--- a/client/src/components/KanbanColumn/index.tsx
+++ b/client/src/components/KanbanColumn/index.tsx
@@ -27,7 +27,6 @@ const KanbanColumn = ({
     category: StatusType,
   ) => {
     dragOverRef.current = order;
-    // 바닥에 파란색 선이 나타나도록 작성
     const dragOverItem = storyList.find((v) => v.id === dragOverRef.current);
     // TODO immerJS 를 통해서 새로운 배열을 만들고, 이에 대해서 update 하는 함수
     draggingRef.current = dragOverRef.current;
@@ -36,12 +35,13 @@ const KanbanColumn = ({
 
   return (
     <Styled.Column>
-      <h4
+      <Styled.KanBanColumnTitle
         onDragEnter={() => setTopEnter((isTopEnter) => !isTopEnter)}
         onDragLeave={() => setTopEnter(false)}
+        isTopEnter={isTopEnter}
       >
         {category}
-      </h4>
+      </Styled.KanBanColumnTitle>
       {storyList?.map((story) => (
         <KanbanItem
           key={story.id}
@@ -50,7 +50,7 @@ const KanbanColumn = ({
           handleDragEnter={handleDragEnter}
         />
       ))}
-      <KanbanAddBtn />
+      {category === 'TODO' && <KanbanAddBtn />}
     </Styled.Column>
   );
 };

--- a/client/src/components/KanbanColumn/index.tsx
+++ b/client/src/components/KanbanColumn/index.tsx
@@ -26,11 +26,12 @@ const KanbanColumn = ({
     // 동일한 칼럼 내의 최상단
     if (isTopEnter && isEqualCategory(draggingCategory, category)) {
       const toBeChangeItem = filterList.find((v) => v.order === draggingRef.current);
-      if (!toBeChangeItem) return;
       const firstnSecondItem = filterList
         .sort((a, b) => Number(a.order) - Number(b.order))
         .slice(0, 2);
       const averageOrder = firstnSecondItem.length > 1 ? Number(firstnSecondItem[1].order) / 2 : 1;
+
+      if (!toBeChangeItem) return;
       dispatchStory({
         type: 'UPDATE_STORY',
         story: { ...toBeChangeItem, order: 0 },
@@ -62,7 +63,7 @@ const KanbanColumn = ({
       return;
     }
 
-    // 다른 칼럼 내에 Item 이 위치
+    // 다른 칼럼 내에 Item 이 위치 && Item 사이 또는 최하단
     if (!isTopEnter && !isEqualCategory(draggingCategory, category)) {
       const toBeChangeItem = storyList
         .filter((v) => v.status === draggingCategory.current)
@@ -80,6 +81,35 @@ const KanbanColumn = ({
       });
       draggingRef.current = null;
       dragOverRef.current = null;
+      return;
+    }
+
+    // 다른 칼럼 내애 Item 위치 && 최상단 위치
+    if (isTopEnter && !isEqualCategory(draggingCategory, category)) {
+      const toBeChangeItem = storyList
+        .filter((v) => v.status === draggingCategory.current)
+        .find((v) => v.order === draggingRef.current);
+      const firstnSecondItem = filterList
+        .sort((a, b) => Number(a.order) - Number(b.order))
+        .slice(0, 2);
+      const averageOrder = firstnSecondItem.length > 1 ? Number(firstnSecondItem[1].order) / 2 : 1;
+
+      if (!toBeChangeItem) return;
+      dispatchStory({
+        type: 'UPDATE_STORY',
+        story: { ...toBeChangeItem, status: category, order: 0 },
+      });
+
+      setTopEnter((isTopEnter) => !isTopEnter);
+      draggingRef.current = null;
+      dragOverRef.current = null;
+
+      if (firstnSecondItem.length < 1) return;
+      dispatchStory({
+        type: 'UPDATE_STORY',
+        story: { ...firstnSecondItem[0], order: averageOrder },
+      });
+
       return;
     }
   };

--- a/client/src/components/KanbanColumn/index.tsx
+++ b/client/src/components/KanbanColumn/index.tsx
@@ -9,32 +9,13 @@ const KanbanColumn = ({
   storyList,
   draggingRef,
   dragOverRef,
-  categoryRef,
+  draggingCategory,
+  dragOverCategory,
 }: KanbanType) => {
   const [isTopEnter, setTopEnter] = useState(false);
   const dispatchStory = useStoryDispatch();
-  const handleDragStart = (
-    e: React.DragEvent<HTMLElement>,
-    order: number,
-    category: StatusType,
-  ) => {
-    draggingRef.current = order;
-    categoryRef.current = category;
-  };
 
-  const handleDragEnter = (
-    e: React.DragEvent<HTMLElement>,
-    order: number,
-    category: StatusType,
-  ) => {
-    dragOverRef.current = order;
-  };
-
-  const handleDragDrop = (
-    e: React.DragEvent<HTMLElement>,
-    order?: number,
-    category?: StatusType,
-  ) => {
+  const handleDragDrop = (category?: StatusType) => {
     // 동일한 칼럼 내의 제일 상단에 Item 을 놓을 때
     if (isTopEnter) {
       const toBeChangeItem = storyList.find((v) => v.order === draggingRef.current);
@@ -57,7 +38,7 @@ const KanbanColumn = ({
       return;
     }
 
-    // 동일한 컬럼 내의 Item 의 사이에 위치
+    // 동일한 컬럼 내의 Item 의 사이 또는 최하단 위치
     if (!isTopEnter) {
       const toBeChangeItem = storyList.find((v) => v.order === draggingRef.current);
       const dragOverOrderList = storyList
@@ -73,23 +54,16 @@ const KanbanColumn = ({
       dragOverRef.current = null;
     }
 
-    // 동일 칼럼의 맨 아래 부분에 위치할 때
     // 다른 칼럼 내에 Item 이 위치
   };
 
   return (
-    <Styled.Column
-    // onDragEnter={() => setTopEnter((isTopEnter) => !isTopEnter)}
-    // onDragLeave={() => setTopEnter(false)}
-    // onDrop={() => handleDragDrop}
-    >
+    <Styled.Column>
       <Styled.KanBanColumnTitle
         onDragOver={(e) => e.preventDefault()}
         onDragEnter={() => setTopEnter((isTopEnter) => !isTopEnter)}
         onDragLeave={() => setTopEnter(false)}
-        onDrop={(e) => {
-          handleDragDrop(e, 1, 'TODO');
-        }}
+        onDrop={() => handleDragDrop('TODO')}
         isTopEnter={isTopEnter}
       >
         {category}
@@ -98,9 +72,11 @@ const KanbanColumn = ({
         <KanbanItem
           key={story.id}
           story={story}
-          handleDragStart={handleDragStart}
-          handleDragEnter={handleDragEnter}
           handleDragDrop={handleDragDrop}
+          draggingRef={draggingRef}
+          draggingCategory={draggingCategory}
+          dragOverRef={dragOverRef}
+          dragOverCategory={dragOverCategory}
         />
       ))}
       {category === 'TODO' && <KanbanAddBtn />}

--- a/client/src/components/KanbanColumn/index.tsx
+++ b/client/src/components/KanbanColumn/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Styled from '@/components/KanbanColumn/style';
 import { KanbanItem, KanbanAddBtn } from '@/components';
-import { StatusType, KanbanType, StoryType } from '@/types/story';
+import { StatusType, KanbanType } from '@/types/story';
 import { useStoryDispatch } from '@/lib/hooks/useContextHooks';
 
 const KanbanColumn = ({
@@ -28,38 +28,68 @@ const KanbanColumn = ({
     category: StatusType,
   ) => {
     dragOverRef.current = order;
-    const dragOverItem = storyList.find((v) => v.id === dragOverRef.current);
-    // TODO immerJS 를 통해서 새로운 배열을 만들고, 이에 대해서 update 하는 함수
-    // draggingRef.current = dragOverRef.current;
   };
 
-  console.log(storyList);
   const handleDragDrop = (
     e: React.DragEvent<HTMLElement>,
     order?: number,
-    category: StatusType,
+    category?: StatusType,
   ) => {
-    const toBeChangeItem = storyList.find((v) => v.order === draggingRef.current);
-    const dragOverOrderList = storyList
-      .map((v) => Number(v.order))
-      .filter((v) => v >= Number(dragOverRef.current))
-      .slice(0, 2);
-    const averageOrder = dragOverOrderList.reduce((prev, cur) => prev + cur, 0) / 2;
-    if (!toBeChangeItem) return;
-    dispatchStory({ type: 'UPDATE_STORY', story: { ...toBeChangeItem, order: averageOrder } });
-    draggingRef.current = null;
-    dragOverRef.current = null;
+    // 동일한 칼럼 내의 제일 상단에 Item 을 놓을 때
+    if (isTopEnter) {
+      const toBeChangeItem = storyList.find((v) => v.order === draggingRef.current);
+      if (!toBeChangeItem) return;
+      const firstnSecondItem = storyList
+        .sort((a, b) => Number(a.order) - Number(b.order))
+        .slice(0, 2);
+      const averageOrder = firstnSecondItem.length > 1 ? Number(firstnSecondItem[1].order) / 2 : 1;
+      dispatchStory({
+        type: 'UPDATE_STORY',
+        story: { ...toBeChangeItem, order: 0 },
+      });
+      dispatchStory({
+        type: 'UPDATE_STORY',
+        story: { ...firstnSecondItem[0], order: averageOrder },
+      });
+      setTopEnter((isTopEnter) => !isTopEnter);
+      draggingRef.current = null;
+      dragOverRef.current = null;
+      return;
+    }
+
+    // 동일한 컬럼 내의 Item 의 사이에 위치
+    if (!isTopEnter) {
+      const toBeChangeItem = storyList.find((v) => v.order === draggingRef.current);
+      const dragOverOrderList = storyList
+        .map((v) => Number(v.order))
+        .filter((v) => v >= Number(dragOverRef.current))
+        .slice(0, 2);
+      const orderSum = dragOverOrderList.reduce((prev, cur) => prev + cur, 0);
+      const avgOrderSum = dragOverOrderList.length > 1 ? orderSum / 2 : orderSum + 1;
+
+      if (!toBeChangeItem) return;
+      dispatchStory({ type: 'UPDATE_STORY', story: { ...toBeChangeItem, order: avgOrderSum } });
+      draggingRef.current = null;
+      dragOverRef.current = null;
+    }
+
+    // 동일 칼럼의 맨 아래 부분에 위치할 때
+    // 다른 칼럼 내에 Item 이 위치
   };
 
   return (
     <Styled.Column
-      onDragEnter={() => setTopEnter((isTopEnter) => !isTopEnter)}
-      onDragLeave={() => setTopEnter(false)}
-      onDrop={() => handleDragDrop}
+    // onDragEnter={() => setTopEnter((isTopEnter) => !isTopEnter)}
+    // onDragLeave={() => setTopEnter(false)}
+    // onDrop={() => handleDragDrop}
     >
       <Styled.KanBanColumnTitle
+        onDragOver={(e) => e.preventDefault()}
         onDragEnter={() => setTopEnter((isTopEnter) => !isTopEnter)}
         onDragLeave={() => setTopEnter(false)}
+        onDrop={(e) => {
+          handleDragDrop(e, 1, 'TODO');
+        }}
         isTopEnter={isTopEnter}
       >
         {category}

--- a/client/src/components/KanbanColumn/style.ts
+++ b/client/src/components/KanbanColumn/style.ts
@@ -1,5 +1,9 @@
 import styled from 'styled-components';
 
+interface KanbanColumnPropType {
+  isTopEnter: boolean;
+}
+
 const Styled = {
   Column: styled.div`
     width: 30%;
@@ -14,20 +18,31 @@ const Styled = {
     border-radius: 8px;
     background-color: ${({ theme }) => theme.color.white};
 
-    h4 {
-      padding-top: 12px;
-      font: ${({ theme }) => theme.font.bold_regular};
-    }
-
     button {
       width: 250px;
       height: 50px;
-
       position: absolute;
       bottom: 15px;
-
       color: ${({ theme }) => theme.color.gray400};
     }
+
+    article {
+      margin-top: 10px;
+    }
+
+    article:nth-child(2) {
+      margin-top: 0px;
+    }
+  `,
+  KanBanColumnTitle: styled.h4<KanbanColumnPropType>`
+    width: 90%;
+    text-align: center;
+    padding-top: 12px;
+    padding-bottom: 8px;
+    font: ${({ theme }) => theme.font.bold_regular};
+    border-bottom: 4px solid transparent;
+    border-bottom: ${({ isTopEnter, theme }) => isTopEnter && `4px solid${theme.color.blue200}`};
+    z-index: 2;
   `,
 };
 

--- a/client/src/components/KanbanItem/index.tsx
+++ b/client/src/components/KanbanItem/index.tsx
@@ -28,7 +28,10 @@ const KanbanItem = ({ story, handleDragStart, handleDragEnter }: KanbanItemType)
   return (
     <Styled.KanBanItem
       data-key={story.id}
-      onDragStart={(e) => handleDragStart(e, story.order as number, story.status)}
+      onDragStart={(e) => {
+        handleDragStart(e, story.order as number, story.status);
+        setDragEnter(false);
+      }}
       onDragEnter={(e) => {
         handleDragEnter(e, story.order as number, story.status);
         setDragEnter((isDragEnter) => !isDragEnter);

--- a/client/src/components/KanbanItem/index.tsx
+++ b/client/src/components/KanbanItem/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import Styled from '@/components/KanbanItem/style';
 import { StoryType } from '@/types/story';
 import { KanbanModalContext } from '@/components/KanbanModal';
@@ -15,6 +15,7 @@ const KanbanItem = ({ story, handleDragStart, handleDragEnter }: KanbanItemType)
   const modalConsumer = useContext(KanbanModalContext);
   const dispatchStory = useStoryDispatch();
   const { key, value, onChange } = useInput('');
+  const [isDragEnter, setDragEnter] = useState(false);
 
   const useUpdateStoryName = () => {
     dispatchStory({
@@ -27,9 +28,14 @@ const KanbanItem = ({ story, handleDragStart, handleDragEnter }: KanbanItemType)
   return (
     <Styled.KanBanItem
       data-key={story.id}
-      onDragStart={(e) => handleDragStart(e, story.order, story.status)}
-      onDragEnter={(e) => handleDragEnter(e, story.order, story.status)}
+      onDragStart={(e) => handleDragStart(e, story.order as number, story.status)}
+      onDragEnter={(e) => {
+        handleDragEnter(e, story.order as number, story.status);
+        setDragEnter((isDragEnter) => !isDragEnter);
+      }}
+      onDragLeave={(e) => setDragEnter((isDragEnter) => !isDragEnter)}
       onDragOver={(e) => e.preventDefault()}
+      isDragEnter={isDragEnter}
       draggable
     >
       <input
@@ -42,7 +48,7 @@ const KanbanItem = ({ story, handleDragStart, handleDragEnter }: KanbanItemType)
       <Styled.CancelIcon
         onClick={() => {
           modalConsumer?.setShowModal(true);
-          modalConsumer?.setDeleteItem(story.id);
+          modalConsumer?.setDeleteItem(story.id as number);
         }}
       ></Styled.CancelIcon>
     </Styled.KanBanItem>

--- a/client/src/components/KanbanItem/index.tsx
+++ b/client/src/components/KanbanItem/index.tsx
@@ -4,7 +4,12 @@ import { KanbanItemType } from '@/types/story';
 import { KanbanModalContext } from '@/components/KanbanModal';
 import { KanbanItemInput } from '@/components';
 
-const KanbanItem = ({ story, handleDragStart, handleDragEnter }: KanbanItemType) => {
+const KanbanItem = ({
+  story,
+  handleDragStart,
+  handleDragEnter,
+  handleDragDrop,
+}: KanbanItemType) => {
   const modalConsumer = useContext(KanbanModalContext);
   const [isDragEnter, setDragEnter] = useState(false);
 
@@ -19,6 +24,10 @@ const KanbanItem = ({ story, handleDragStart, handleDragEnter }: KanbanItemType)
         handleDragEnter(e, story.order as number, story.status);
         setDragEnter((isDragEnter) => !isDragEnter);
       }}
+      onDrop={(e) => {
+        handleDragDrop(e, story.order as number, story.status);
+        setDragEnter(false);
+      }}
       onDragLeave={() => setDragEnter((isDragEnter) => !isDragEnter)}
       onDragOver={(e) => e.preventDefault()}
       isDragEnter={isDragEnter}
@@ -30,7 +39,7 @@ const KanbanItem = ({ story, handleDragStart, handleDragEnter }: KanbanItemType)
           modalConsumer?.setShowModal(true);
           modalConsumer?.setDeleteItem(story.id as number);
         }}
-      ></Styled.CancelIcon>
+      />
     </Styled.KanBanItem>
   );
 };

--- a/client/src/components/KanbanItem/index.tsx
+++ b/client/src/components/KanbanItem/index.tsx
@@ -3,11 +3,14 @@ import Styled from '@/components/KanbanItem/style';
 import { KanbanItemType } from '@/types/story';
 import { KanbanModalContext } from '@/components/KanbanModal';
 import { KanbanItemInput } from '@/components';
+import { handleDragStart, handleDragEnter } from '@/lib/utils/drag';
 
 const KanbanItem = ({
   story,
-  handleDragStart,
-  handleDragEnter,
+  draggingRef,
+  draggingCategory,
+  dragOverRef,
+  dragOverCategory,
   handleDragDrop,
 }: KanbanItemType) => {
   const modalConsumer = useContext(KanbanModalContext);
@@ -17,15 +20,15 @@ const KanbanItem = ({
     <Styled.KanBanItem
       data-key={story.id}
       onDragStart={(e) => {
-        handleDragStart(e, story.order as number, story.status);
+        handleDragStart(e, story.order as number, story.status, draggingRef, draggingCategory);
         setDragEnter(false);
       }}
       onDragEnter={(e) => {
-        handleDragEnter(e, story.order as number, story.status);
+        handleDragEnter(e, story.order as number, story.status, dragOverRef, dragOverCategory);
         setDragEnter((isDragEnter) => !isDragEnter);
       }}
       onDrop={(e) => {
-        handleDragDrop(e, story.order as number, story.status);
+        handleDragDrop(story.status);
         setDragEnter(false);
       }}
       onDragLeave={() => setDragEnter((isDragEnter) => !isDragEnter)}

--- a/client/src/components/KanbanItem/index.tsx
+++ b/client/src/components/KanbanItem/index.tsx
@@ -1,15 +1,10 @@
 import React, { useContext, useState } from 'react';
 import Styled from '@/components/KanbanItem/style';
-import { StoryType } from '@/types/story';
+import { KanbanItemType } from '@/types/story';
 import { KanbanModalContext } from '@/components/KanbanModal';
 import { useStoryDispatch } from '@/lib/hooks/useContextHooks';
 import { useInput } from '@/lib/hooks';
 import { updateStoryWithName } from '@/lib/api/story';
-import { KanbanDefaultType } from '@/layers/Kanban';
-
-interface KanbanItemType extends KanbanDefaultType {
-  story: StoryType;
-}
 
 const KanbanItem = ({ story, handleDragStart, handleDragEnter }: KanbanItemType) => {
   const modalConsumer = useContext(KanbanModalContext);
@@ -36,7 +31,7 @@ const KanbanItem = ({ story, handleDragStart, handleDragEnter }: KanbanItemType)
         handleDragEnter(e, story.order as number, story.status);
         setDragEnter((isDragEnter) => !isDragEnter);
       }}
-      onDragLeave={(e) => setDragEnter((isDragEnter) => !isDragEnter)}
+      onDragLeave={() => setDragEnter((isDragEnter) => !isDragEnter)}
       onDragOver={(e) => e.preventDefault()}
       isDragEnter={isDragEnter}
       draggable

--- a/client/src/components/KanbanItem/index.tsx
+++ b/client/src/components/KanbanItem/index.tsx
@@ -2,23 +2,11 @@ import React, { useContext, useState } from 'react';
 import Styled from '@/components/KanbanItem/style';
 import { KanbanItemType } from '@/types/story';
 import { KanbanModalContext } from '@/components/KanbanModal';
-import { useStoryDispatch } from '@/lib/hooks/useContextHooks';
-import { useInput } from '@/lib/hooks';
-import { updateStoryWithName } from '@/lib/api/story';
+import { KanbanInput } from '@/components';
 
 const KanbanItem = ({ story, handleDragStart, handleDragEnter }: KanbanItemType) => {
   const modalConsumer = useContext(KanbanModalContext);
-  const dispatchStory = useStoryDispatch();
-  const { key, value, onChange } = useInput('');
   const [isDragEnter, setDragEnter] = useState(false);
-
-  const useUpdateStoryName = () => {
-    dispatchStory({
-      type: 'UPDATE_STORY',
-      story: { status: 'TODO', id: key, order: story.order, name: value },
-    });
-    updateStoryWithName({ status: 'TODO', id: key, order: story.order, name: value });
-  };
 
   return (
     <Styled.KanBanItem
@@ -36,13 +24,7 @@ const KanbanItem = ({ story, handleDragStart, handleDragEnter }: KanbanItemType)
       isDragEnter={isDragEnter}
       draggable
     >
-      <input
-        type="text"
-        placeholder={story.name ? story.name : 'type a todo...'}
-        data-key={story.id}
-        onChange={onChange}
-        onBlur={useUpdateStoryName}
-      />
+      <KanbanInput story={story} />
       <Styled.CancelIcon
         onClick={() => {
           modalConsumer?.setShowModal(true);

--- a/client/src/components/KanbanItem/index.tsx
+++ b/client/src/components/KanbanItem/index.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useState } from 'react';
 import Styled from '@/components/KanbanItem/style';
 import { KanbanItemType } from '@/types/story';
 import { KanbanModalContext } from '@/components/KanbanModal';
-import { KanbanInput } from '@/components';
+import { KanbanItemInput } from '@/components';
 
 const KanbanItem = ({ story, handleDragStart, handleDragEnter }: KanbanItemType) => {
   const modalConsumer = useContext(KanbanModalContext);
@@ -24,7 +24,7 @@ const KanbanItem = ({ story, handleDragStart, handleDragEnter }: KanbanItemType)
       isDragEnter={isDragEnter}
       draggable
     >
-      <KanbanInput story={story} />
+      <KanbanItemInput story={story} />
       <Styled.CancelIcon
         onClick={() => {
           modalConsumer?.setShowModal(true);

--- a/client/src/components/KanbanItem/style.ts
+++ b/client/src/components/KanbanItem/style.ts
@@ -10,7 +10,7 @@ const Styled = {
     width: 90%;
     height: 65px;
     border-radius: 8px;
-    margin-top: 10px;
+
     display: flex;
     cursor: grab;
     background-color: ${({ theme }) => theme.color.gray100};

--- a/client/src/components/KanbanItem/style.ts
+++ b/client/src/components/KanbanItem/style.ts
@@ -17,19 +17,6 @@ const Styled = {
     border-bottom: ${({ isDragEnter, theme }) => isDragEnter && `4px solid ${theme.color.blue200}`};
     border-bottom-left-radius: ${({ isDragEnter }) => isDragEnter && '2px'};
     border-bottom-right-radius: ${({ isDragEnter }) => isDragEnter && '2px'};
-
-    input {
-      background-color: ${({ theme }) => theme.color.gray100};
-
-      margin-top: 15px;
-      padding: 15px;
-      width: 90%;
-      height: 30px;
-
-      font: ${({ theme }) => theme.font.bold_small};
-      font-size: 14px;
-      cursor: grab;
-    }
   `,
 
   CancelIcon: styled.p`

--- a/client/src/components/KanbanItem/style.ts
+++ b/client/src/components/KanbanItem/style.ts
@@ -1,15 +1,22 @@
 import styled from 'styled-components';
 import cancelicon from '@public/icons/cancel-icon.svg';
 
+interface KanbanItemPropType {
+  isDragEnter: boolean;
+}
+
 const Styled = {
-  KanBanItem: styled.article`
+  KanBanItem: styled.article<KanbanItemPropType>`
     width: 90%;
     height: 65px;
     border-radius: 8px;
     margin-top: 10px;
     display: flex;
-    cursor: move;
+    cursor: grab;
     background-color: ${({ theme }) => theme.color.gray100};
+    border-bottom: ${({ isDragEnter, theme }) => isDragEnter && `4px solid ${theme.color.blue200}`};
+    border-bottom-left-radius: ${({ isDragEnter }) => isDragEnter && '2px'};
+    border-bottom-right-radius: ${({ isDragEnter }) => isDragEnter && '2px'};
 
     input {
       background-color: ${({ theme }) => theme.color.gray100};
@@ -21,6 +28,7 @@ const Styled = {
 
       font: ${({ theme }) => theme.font.bold_small};
       font-size: 14px;
+      cursor: grab;
     }
   `,
 

--- a/client/src/components/KanbanItemInput/index.tsx
+++ b/client/src/components/KanbanItemInput/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Input from './style';
+import { useStoryDispatch } from '@/lib/hooks/useContextHooks';
+import { useInput } from '@/lib/hooks';
+import { updateStoryWithName } from '@/lib/api/story';
+import { StoryType } from '@/types/story';
+
+const KanbanInput = ({ story }: { story: StoryType }) => {
+  const dispatchStory = useStoryDispatch();
+  const { key, value, onChange } = useInput('');
+  const useUpdateStoryName = () => {
+    dispatchStory({
+      type: 'UPDATE_STORY',
+      story: { status: 'TODO', id: key, order: story.order, name: value },
+    });
+    updateStoryWithName({ status: 'TODO', id: key, order: story.order, name: value });
+  };
+
+  return (
+    <Input
+      type="text"
+      placeholder={story.name ? story.name : 'type a todo...'}
+      data-key={story.id}
+      onChange={onChange}
+      onBlur={useUpdateStoryName}
+    />
+  );
+};
+
+export default KanbanInput;

--- a/client/src/components/KanbanItemInput/style.ts
+++ b/client/src/components/KanbanItemInput/style.ts
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+const Input = styled.input`
+  background-color: ${({ theme }) => theme.color.gray100};
+
+  margin-top: 15px;
+  padding: 15px;
+  width: 90%;
+  height: 30px;
+
+  font: ${({ theme }) => theme.font.bold_small};
+  font-size: 14px;
+  cursor: grab;
+`;
+
+export default Input;

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -14,7 +14,8 @@ export { default as SideBarEntry } from './SideBarEntry/index';
 export { default as EpicPlaceholer } from './EpicPlaceholder/index';
 
 // KanBan
-export { default as KanbanItem } from './KanbanItem/index';
 export { default as KanbanColumn } from './KanbanColumn/index';
+export { default as KanbanItem } from './KanbanItem/index';
+export { default as KanbanItemInput } from './KanbanItemInput/index';
 export { default as KanbanAddBtn } from './KanbanAddBtn/index';
 export { default as KanbanModal } from './KanbanModal/index';

--- a/client/src/layers/Kanban/index.tsx
+++ b/client/src/layers/Kanban/index.tsx
@@ -8,7 +8,8 @@ import { useStoryState } from '@/lib/hooks/useContextHooks';
 const Kanban = () => {
   const draggingRef = useRef<number | null>(0);
   const dragOverRef = useRef<number | null>(0);
-  const cateogryRef = useRef<StatusType>('TODO');
+  const draggingCategory = useRef<StatusType>('TODO');
+  const dragOverCateogry = useRef<StatusType>('TODO');
   const storyList: StoryType[] = useStoryState();
 
   const todoList = storyList
@@ -27,14 +28,29 @@ const Kanban = () => {
         <Styled.Title>프로젝트 칸반보드</Styled.Title>
         <Styled.ColumnContainer>
           <KanbanColumn
-            draggingRef={draggingRef}
-            dragOverRef={dragOverRef}
-            categoryRef={cateogryRef}
             category={'TODO'}
             storyList={todoList}
+            draggingRef={draggingRef}
+            dragOverRef={dragOverRef}
+            draggingCategory={draggingCategory}
+            dragOverCategory={dragOverCateogry}
           />
-          <KanbanColumn category={'IN_PROGRESS'} storyList={onGoingList} />
-          <KanbanColumn category={'DONE'} storyList={finishList} />
+          <KanbanColumn
+            category={'IN_PROGRESS'}
+            storyList={onGoingList}
+            draggingRef={draggingRef}
+            dragOverRef={dragOverRef}
+            draggingCategory={draggingCategory}
+            dragOverCategory={dragOverCateogry}
+          />
+          <KanbanColumn
+            category={'DONE'}
+            storyList={finishList}
+            draggingRef={draggingRef}
+            dragOverRef={dragOverRef}
+            draggingCategory={draggingCategory}
+            dragOverCategory={dragOverCateogry}
+          />
         </Styled.ColumnContainer>
       </Styled.Container>
     </KanbanModal>

--- a/client/src/layers/Kanban/index.tsx
+++ b/client/src/layers/Kanban/index.tsx
@@ -18,13 +18,13 @@ const Kanban = () => {
 
   const todoList = storyList
     .filter((item) => item.status === 'TODO')
-    .sort((a, b) => a.order - b.order);
+    .sort((a, b) => Number(a.order) - Number(b.order));
   const onGoingList = storyList
     .filter((item) => item.status === 'IN_PROGRESS')
-    .sort((a, b) => a.order - b.order);
+    .sort((a, b) => Number(a.order) - Number(b.order));
   const finishList = storyList
     .filter((item) => item.status === 'DONE')
-    .sort((a, b) => a.order - b.order);
+    .sort((a, b) => Number(a.order) - Number(b.order));
 
   return (
     <KanbanModal>

--- a/client/src/layers/Kanban/index.tsx
+++ b/client/src/layers/Kanban/index.tsx
@@ -2,25 +2,13 @@ import React, { useRef } from 'react';
 import Styled from '@/layers/Kanban/style';
 import KanbanColumn from '@/components/KanbanColumn';
 import KanbanModal from '@/components/KanbanModal';
-import { StoryType, StatusType } from '@/types/story';
-import { useStoryState } from '@/lib/hooks/useContextHooks';
+import { StatusType } from '@/types/story';
 
 const Kanban = () => {
   const draggingRef = useRef<number | null>(0);
   const dragOverRef = useRef<number | null>(0);
   const draggingCategory = useRef<StatusType>('TODO');
   const dragOverCateogry = useRef<StatusType>('TODO');
-  const storyList: StoryType[] = useStoryState();
-
-  const todoList = storyList
-    .filter((item) => item.status === 'TODO')
-    .sort((a, b) => Number(a.order) - Number(b.order));
-  const onGoingList = storyList
-    .filter((item) => item.status === 'IN_PROGRESS')
-    .sort((a, b) => Number(a.order) - Number(b.order));
-  const finishList = storyList
-    .filter((item) => item.status === 'DONE')
-    .sort((a, b) => Number(a.order) - Number(b.order));
 
   return (
     <KanbanModal>
@@ -29,7 +17,6 @@ const Kanban = () => {
         <Styled.ColumnContainer>
           <KanbanColumn
             category={'TODO'}
-            storyList={todoList}
             draggingRef={draggingRef}
             dragOverRef={dragOverRef}
             draggingCategory={draggingCategory}
@@ -37,7 +24,6 @@ const Kanban = () => {
           />
           <KanbanColumn
             category={'IN_PROGRESS'}
-            storyList={onGoingList}
             draggingRef={draggingRef}
             dragOverRef={dragOverRef}
             draggingCategory={draggingCategory}
@@ -45,7 +31,6 @@ const Kanban = () => {
           />
           <KanbanColumn
             category={'DONE'}
-            storyList={finishList}
             draggingRef={draggingRef}
             dragOverRef={dragOverRef}
             draggingCategory={draggingCategory}

--- a/client/src/layers/Kanban/index.tsx
+++ b/client/src/layers/Kanban/index.tsx
@@ -5,11 +5,6 @@ import KanbanModal from '@/components/KanbanModal';
 import { StoryType, StatusType } from '@/types/story';
 import { useStoryState } from '@/lib/hooks/useContextHooks';
 
-export interface KanbanDefaultType {
-  handleDragStart(e: React.DragEvent<HTMLElement>, order: number, category: StatusType): void;
-  handleDragEnter(e: React.DragEvent<HTMLElement>, order: number, category: StatusType): void;
-}
-
 const Kanban = () => {
   const draggingRef = useRef<number | null>(0);
   const dragOverRef = useRef<number | null>(0);

--- a/client/src/lib/api/story.ts
+++ b/client/src/lib/api/story.ts
@@ -17,32 +17,26 @@ export const getAllStories = async (projectId: number | string) => {
   }
 };
 
-/**
- * @param storyId 스토리 id
- * @param status 스토리의 상태
- * @param projectId 프로젝트 id
- * @param storyName 스토리 이름
- * @param epicId 에픽 id
- * @returns id 를 프로퍼티로 가지는 객체, 스토리 생성 성공시 생성된 스토리의 id, 실패시 -1값 { id: number }
- */
-export const createStory = async ({
-  id,
-  status,
-  name,
-  order,
-  projectId = 1,
-  epicId = 1,
-}: StoryType) => {
+export const getStoryByid = async (storyId: number | string) => {
   try {
-    const result: { data: { id: number } } = await instance.post('', {
-      id,
+    console.log(storyId);
+    const result: { data: StoryType } = await instance.get(`/${storyId}`);
+    return result.data;
+  } catch (e) {
+    toast.error(errorMessage.GET_STORY);
+  }
+};
+
+export const postStory = async ({ status, name, order, projectId = 1, epicId = 1 }: StoryType) => {
+  try {
+    const result = await instance.post('', {
       status,
       name,
       order,
       projectId,
       epicId,
     });
-    return result.data;
+    return result.data.id;
   } catch (e) {
     toast.error(errorMessage.CREATE_STORY);
   }

--- a/client/src/lib/api/story.ts
+++ b/client/src/lib/api/story.ts
@@ -51,7 +51,7 @@ export const updateStoryWithName = async ({
 }: StoryType) => {
   if (name === '') return;
   try {
-    const result: { data: { id: number } } = await instance.patch('/name', {
+    const result: { data: { id: number } } = await instance.patch(`/name/${id}`, {
       id,
       status,
       name,
@@ -74,8 +74,7 @@ export const updateStoryWithId = async ({
   epicId,
 }: StoryType) => {
   try {
-    const result: { data: { id: number } } = await instance.patch('/order', {
-      id,
+    const result: { data: { id: number } } = await instance.patch(`/order/${id}`, {
       status,
       name,
       order,

--- a/client/src/lib/api/story.ts
+++ b/client/src/lib/api/story.ts
@@ -19,7 +19,6 @@ export const getAllStories = async (projectId: number | string) => {
 
 export const getStoryByid = async (storyId: number | string) => {
   try {
-    console.log(storyId);
     const result: { data: StoryType } = await instance.get(`/${storyId}`);
     return result.data;
   } catch (e) {

--- a/client/src/lib/utils/drag.ts
+++ b/client/src/lib/utils/drag.ts
@@ -1,0 +1,23 @@
+import { StatusType, dragRefObjectType, dragCategoryType } from '@/types/story';
+
+export const handleDragStart = (
+  e: React.DragEvent<HTMLElement>,
+  order: number,
+  category: StatusType,
+  draggingRef: dragRefObjectType,
+  draggingCategory: dragCategoryType,
+) => {
+  draggingRef.current = order;
+  draggingCategory.current = category;
+};
+
+export const handleDragEnter = (
+  e: React.DragEvent<HTMLElement>,
+  order: number,
+  category: StatusType,
+  dragOverRef: dragRefObjectType,
+  dragOverCategory: dragCategoryType,
+) => {
+  dragOverRef.current = order;
+  dragOverCategory.current = category;
+};

--- a/client/src/types/story.d.ts
+++ b/client/src/types/story.d.ts
@@ -1,9 +1,9 @@
 export type StatusType = 'TODO' | 'IN_PROGRESS' | 'DONE';
 
 export type StoryType = {
-  id: number;
   name: string;
   status: StoryStatusType;
+  id?: number;
   order?: number;
   projectId?: number;
   epicId?: number;

--- a/client/src/types/story.d.ts
+++ b/client/src/types/story.d.ts
@@ -21,4 +21,5 @@ export interface KanbanItemType {
   story: StoryType;
   handleDragStart(e: React.DragEvent<HTMLElement>, order: number, category: StatusType): void;
   handleDragEnter(e: React.DragEvent<HTMLElement>, order: number, category: StatusType): void;
+  handleDragDrop(e: React.DragEvent<HTMLElement>, order: number, category: StatusType): void;
 }

--- a/client/src/types/story.d.ts
+++ b/client/src/types/story.d.ts
@@ -14,7 +14,6 @@ export type dragRefObjectType = React.MutableRefObject<number | null>;
 export type dragCategoryType = React.MutableRefObject<StatusType>;
 
 export interface KanbanType {
-  storyList: Array<StoryType>;
   category: StatusType;
   draggingRef: dragRefObjectType;
   dragOverRef: dragRefObjectType;

--- a/client/src/types/story.d.ts
+++ b/client/src/types/story.d.ts
@@ -4,7 +4,7 @@ export type StoryType = {
   id: number;
   name: string;
   status: StoryStatusType;
-  order: number;
+  order?: number;
   projectId?: number;
   epicId?: number;
 };

--- a/client/src/types/story.d.ts
+++ b/client/src/types/story.d.ts
@@ -8,3 +8,17 @@ export type StoryType = {
   projectId?: number;
   epicId?: number;
 };
+
+export interface KanbanType {
+  storyList: Array<StoryType>;
+  category: StatusType;
+  draggingRef: React.MutableRefObject<number | null>;
+  dragOverRef: React.MutableRefObject<number | null>;
+  categoryRef: React.MutableRefObject<StatusType>;
+}
+
+export interface KanbanItemType {
+  story: StoryType;
+  handleDragStart(e: React.DragEvent<HTMLElement>, order: number, category: StatusType): void;
+  handleDragEnter(e: React.DragEvent<HTMLElement>, order: number, category: StatusType): void;
+}

--- a/client/src/types/story.d.ts
+++ b/client/src/types/story.d.ts
@@ -1,4 +1,3 @@
-import { dragRefObjectType } from './story.d';
 export type StatusType = 'TODO' | 'IN_PROGRESS' | 'DONE';
 
 export type StoryType = {

--- a/client/src/types/story.d.ts
+++ b/client/src/types/story.d.ts
@@ -1,3 +1,4 @@
+import { dragRefObjectType } from './story.d';
 export type StatusType = 'TODO' | 'IN_PROGRESS' | 'DONE';
 
 export type StoryType = {
@@ -9,17 +10,24 @@ export type StoryType = {
   epicId?: number;
 };
 
+export type dragRefObjectType = React.MutableRefObject<number | null>;
+export type dragCategoryType = React.MutableRefObject<StatusType>;
+
 export interface KanbanType {
   storyList: Array<StoryType>;
   category: StatusType;
-  draggingRef: React.MutableRefObject<number | null>;
-  dragOverRef: React.MutableRefObject<number | null>;
-  categoryRef: React.MutableRefObject<StatusType>;
+  draggingRef: dragRefObjectType;
+  dragOverRef: dragRefObjectType;
+  draggingCategory: dragCategoryType;
+  dragOverCategory: dragCategoryType;
 }
 
+//TODO Extends 를 통한 상속
 export interface KanbanItemType {
   story: StoryType;
-  handleDragStart(e: React.DragEvent<HTMLElement>, order: number, category: StatusType): void;
-  handleDragEnter(e: React.DragEvent<HTMLElement>, order: number, category: StatusType): void;
-  handleDragDrop(e: React.DragEvent<HTMLElement>, order: number, category: StatusType): void;
+  draggingRef: dragRefObjectType;
+  dragOverRef: dragRefObjectType;
+  draggingCategory: dragCategoryType;
+  dragOverCategory: dragCategoryType;
+  handleDragDrop(category: StatusType): void;
 }

--- a/server/src/Stories/Stories.controller.ts
+++ b/server/src/Stories/Stories.controller.ts
@@ -75,16 +75,20 @@ export const postStory = async (req: Request, res: Response) => {
 };
 
 export const updateStoryWithName = async (req: Request, res: Response) => {
-  const { id, name, status } = req.body;
+  if (!req.params.id) {
+    throw new Error('유효한 ID 가 존재하지 않습니다.');
+  }
+  const { id } = req.params;
+  const { name, status } = req.body;
   try {
     await getConnection()
       .createQueryBuilder()
       .update(Stories)
-      .set({ id: id, name: name, status: status })
+      .set({ name: name, status: status })
       .where('id = :id', { id: id })
       .execute();
 
-    res.status(201).json({ id: id, name: name });
+    res.end();
   } catch (e) {
     res.status(400).json({
       message: (e as Error).message,
@@ -93,16 +97,20 @@ export const updateStoryWithName = async (req: Request, res: Response) => {
 };
 
 export const updateStoryWithId = async (req: Request, res: Response) => {
-  const { id, name, status, order } = req.body;
+  if (!req.params.id) {
+    throw new Error('유효한 ID 가 존재하지 않습니다.');
+  }
+  const { id } = req.params;
+  const { name, status, order } = req.body;
   try {
     await getConnection()
       .createQueryBuilder()
       .update(Stories)
-      .set({ id: id, name: name, status: status, order: order })
+      .set({ name: name, status: status, order: order })
       .where('id = :id', { id: id })
       .execute();
 
-    res.status(201).json({ id: id, name: name });
+    res.end();
   } catch (e) {
     res.status(400).json({
       message: (e as Error).message,
@@ -119,6 +127,8 @@ export const deleteStoryWithId = async (req: Request, res: Response) => {
       .from(Stories)
       .where('id = :id', { id: storyId })
       .execute();
+
+    res.end();
   } catch (e) {
     res.status(400).json({
       message: (e as Error).message,

--- a/server/src/Stories/Stories.controller.ts
+++ b/server/src/Stories/Stories.controller.ts
@@ -33,6 +33,24 @@ export const getAllStoriesByProject = async (req: Request, res: Response) => {
   }
 };
 
+export const getStoryById = async (req: Request, res: Response) => {
+  try {
+    if (!req.params.id) {
+      throw new Error('유효한 ID 가 존재하지 않습니다.');
+    }
+    const { id } = req.params;
+    const result = await getRepository(Stories).findOne(id);
+    if (!result) {
+      throw new Error(`해당 ${id} 를 조회할 수 없습니다`);
+    }
+    res.status(200).json(result);
+  } catch (e) {
+    res.status(404).json({
+      message: (e as Error).message,
+    });
+  }
+};
+
 export const postStory = async (req: Request, res: Response) => {
   try {
     const result = await getRepository(Stories)

--- a/server/src/Stories/Stories.controller.ts
+++ b/server/src/Stories/Stories.controller.ts
@@ -66,8 +66,7 @@ export const postStory = async (req: Request, res: Response) => {
       })
       .execute();
 
-    const { id, status } = result.generatedMaps[0];
-    res.status(201).json({ id, status });
+    res.status(201).json({ id: result.raw.insertId });
   } catch (e) {
     res.status(400).json({
       message: (e as Error).message,

--- a/server/src/Stories/Stories.controller.ts
+++ b/server/src/Stories/Stories.controller.ts
@@ -53,6 +53,7 @@ export const getStoryById = async (req: Request, res: Response) => {
 
 export const postStory = async (req: Request, res: Response) => {
   try {
+    //TODO 생성 후 생성 결과를 반환하도록 query 문 작성
     const result = await getRepository(Stories)
       .createQueryBuilder()
       .insert()

--- a/server/src/Stories/Stories.controller.ts
+++ b/server/src/Stories/Stories.controller.ts
@@ -33,11 +33,6 @@ export const getAllStoriesByProject = async (req: Request, res: Response) => {
   }
 };
 
-/**
- * @body projectName: string | number 대상 프로젝트의 id값
- * @body name: string 새롭게 생성하는 에픽의 이름
- * @response id: number 새롭게 생성된 에픽의 id값
- */
 export const postStory = async (req: Request, res: Response) => {
   try {
     const result = await getRepository(Stories)
@@ -45,7 +40,6 @@ export const postStory = async (req: Request, res: Response) => {
       .insert()
       .into(Stories)
       .values({
-        id: req.body.id,
         name: req.body.name,
         status: req.body.status,
         order: req.body.order,
@@ -53,7 +47,9 @@ export const postStory = async (req: Request, res: Response) => {
         epics: () => req.body.epicId,
       })
       .execute();
-    res.status(201).json({ id: result.raw.insertId });
+
+    const { id, status } = result.generatedMaps[0];
+    res.status(201).json({ id, status });
   } catch (e) {
     res.status(400).json({
       message: (e as Error).message,

--- a/server/src/Stories/Stories.entity.ts
+++ b/server/src/Stories/Stories.entity.ts
@@ -20,7 +20,7 @@ export default class Stories {
   @Column({ name: 'STATUS', type: 'enum', default: StatusEnum.TODO, enum: StatusEnum })
   status!: StatusEnum;
 
-  @Column('decimal', { name: 'ORDER', precision: 30, scale: 29 })
+  @Column('decimal', { name: 'ORDER', precision: 20, scale: 12 })
   order!: number;
 
   @ManyToOne(() => Projects, (projects) => projects.id)

--- a/server/src/Stories/Stories.router.ts
+++ b/server/src/Stories/Stories.router.ts
@@ -12,7 +12,7 @@ const router = express.Router();
 
 router
   .get('/', getAllStoriesByProject)
-  .get('/id', getStoryById)
+  .get('/:id', getStoryById)
   .post('/', postStory)
   .patch('/name', updateStoryWithName)
   .patch('/order', updateStoryWithId)

--- a/server/src/Stories/Stories.router.ts
+++ b/server/src/Stories/Stories.router.ts
@@ -1,18 +1,21 @@
 import express from 'express';
 import {
-  deleteStoryWithId,
   getAllStoriesByProject,
+  getStoryById,
   postStory,
   updateStoryWithName,
   updateStoryWithId,
+  deleteStoryWithId,
 } from './Stories.controller';
 
 const router = express.Router();
 
-router.get('/', getAllStoriesByProject);
-router.post('/', postStory);
-router.patch('/name', updateStoryWithName);
-router.patch('/order', updateStoryWithId);
-router.delete('/', deleteStoryWithId);
+router
+  .get('/', getAllStoriesByProject)
+  .get('/id', getStoryById)
+  .post('/', postStory)
+  .patch('/name', updateStoryWithName)
+  .patch('/order', updateStoryWithId)
+  .delete('/', deleteStoryWithId);
 
 export default router;

--- a/server/src/Stories/Stories.router.ts
+++ b/server/src/Stories/Stories.router.ts
@@ -14,8 +14,8 @@ router
   .get('/', getAllStoriesByProject)
   .get('/:id', getStoryById)
   .post('/', postStory)
-  .patch('/name', updateStoryWithName)
-  .patch('/order', updateStoryWithId)
+  .patch('/name/:id', updateStoryWithName)
+  .patch('/order/:id', updateStoryWithId)
   .delete('/', deleteStoryWithId);
 
 export default router;


### PR DESCRIPTION
## 😀 제목

칸반 보드 아이템 이동 구현 

## ⛅️ 내용

> 이 PR의 작업 요약

- 정수 자리로 order 를 갖도록 수정완료
- id 를 DB 에서 받아온 이후에 할당하도록 수정 완료
- kanbanAddBtn 에 switch 문 로직 제거
- 칸반 Item 내부에 Input 컴포넌트 분리 (책임 분리)
- 칸반 아이템에 해당 아이템 가져갖을 때 파란색 줄이 나타나게 구현 완료(노션처럼)
- 아이템을 드랍했을 때 해당 위치를찾아가도록 구현완료
- dispatch 를 통한 상태 변경 이후에 story API 를 통해서 order DB 최신화

## 🎸특이사항

> 리뷰시 참고할만한 내용, 주의깊게 봐줬으면 하는 내용

- 아까 회고할 때 말씀해주셨던 post 를 하고 해당 item 을 반환하는 방법을 아직 못찾아서 일단 get 으로 가져오게 구현했습니다.
- 현재는 동일 컬럼내에서 이동이 가능합니다. 

- 마무리될지는 모르겠지만, 구현을 좀 더 해보고 내일 아침에 결과를 말씀드릴게요 👍 
- 크흐....드래그 앤 드랍 끝냈습니다. UX 향상을 위해 필요한 Event Handling 이 하나 정도 더 있을 것 같네요. 쪼갠다고 쪼갰는데 드래그 앤 드랍은 경우의 수가 크게 4가지가 나와서 내일 함수로 또 분리해봐야할 것 같아요. 테스트 코드는 리펙토링 이후에 작성해볼게요....! 여러분들의 0, 1, 2 로 id 를 작성해보라고 하셨던게 아주 저의 작업을 편하게 해주었어요. 감사합니다 :) 영상도 짧게 첨부해봅니다ㅎ

https://user-images.githubusercontent.com/73208317/142909133-e6dcaffc-9f0c-4005-be6f-82cee462a330.mov

