### PR TITLE
fix: 초기값이 빈 문자열이어서 회원가입이 되지 않는 버그 수정

### DIFF
--- a/client/src/pages/SignUpPage/index.tsx
+++ b/client/src/pages/SignUpPage/index.tsx
@@ -25,7 +25,7 @@ const SignUpPage = ({ token }: { token: string }) => {
     password: '',
     checkPassword: '',
     organization: room,
-    imageURL: '',
+    imageURL: 'Boy0',
   });
   const setUserState = useSetRecoilState(userAtom);
 


### PR DESCRIPTION
초기값이 빈 문자열이어서 imageURL이 없다고 인식하여 이 버그를 수정함

## 😀 제목

fix: 초기값이 빈 문자열이어서 회원가입이 되지 않는 버그 수정

## ⛅️ 내용

> 이 PR의 작업 요약

여기에 작성

## 🎸특이사항

> 리뷰시 참고할만한 내용, 주의깊게 봐줬으면 하는 내용

여기에 작성 
