### PR TITLE
todo 유효성 체크 수정 및 에픽 요청 필터링 수정

### DIFF
--- a/client/src/components/TodoInputBar/index.tsx
+++ b/client/src/components/TodoInputBar/index.tsx
@@ -24,7 +24,7 @@ const TodoInputBar = () => {
     event.preventDefault();
     if (typeof userState.id === 'number') {
       const target = todoInput.current as HTMLInputElement;
-      checkObjectInput({ text: target.value });
+      if (!checkObjectInput({ text: target.value })) return;
       const todo = await createTodo(target.value, userState.id);
       if (todo) {
         setAllTasks((prev) => [todo, ...prev]);

--- a/server/src/Epics/Epics.controller.ts
+++ b/server/src/Epics/Epics.controller.ts
@@ -3,6 +3,7 @@ import { queryValidator } from '@/utils/requestValidator';
 import { getRepository } from 'typeorm';
 
 import Epics from './Epics.entity';
+import Projects from '@/Projects/Projects.entity';
 
 const INVALID_ID = 'invalid id';
 
@@ -15,11 +16,13 @@ export const getAllEpicsByProject = async (req: Request, res: Response) => {
     }
     const { projectId } = req.query;
     const epicRepository = getRepository(Epics);
+    const projectRepository = getRepository(Projects);
+    const project = await projectRepository.findOne({ where: { id: projectId } });
+    if (!project) throw new Error('invalid id');
     const epics = await epicRepository.find({
       relations: ['projects'],
       where: { projects: { id: +(projectId as string) } },
     });
-    if (!epics.length) throw new Error('invalid id');
     const result = epics.map((el) => ({
       id: el.id,
       name: el.name,

--- a/server/test/Epics.test.ts
+++ b/server/test/Epics.test.ts
@@ -1,62 +1,9 @@
-import { ConnectionOptions, createConnection, getConnection } from 'typeorm';
-import { entities } from '../src';
 import app from '../app';
 import request from 'supertest';
+import { afterAllFunction, beforeAllfunction } from '.';
 
-beforeAll(async () => {
-  const dbConfig = {
-    host: process.env.DB_HOST,
-    username: process.env.DB_USER,
-    password: process.env.DB_PASSWORD,
-    database: process.env.DB_DATABASE_TEST,
-  };
-
-  const connectionOptions: ConnectionOptions = {
-    type: 'mysql',
-    synchronize: true,
-    entities: entities,
-    ...dbConfig,
-  };
-
-  const connection = await createConnection(connectionOptions);
-  await connection.synchronize();
-  await connection.query(`INSERT INTO ORGANIZATIONS(ROOM) VALUES('TEAM42');`);
-  await connection.query(`INSERT INTO PROJECTS(NAME) VALUES('HYUPUP');`);
-  await connection.query(
-    `INSERT INTO USERS(NAME, JOB, EMAIL, IMAGE_URL, ADMIN, PASSWORD, ORGANIZATION_ID)` +
-      `VALUES('hm', 'developer', 'test@test.com', 'url', 1,` +
-      `'$2b$10$e3kxJ2jBwf/o5rpNgG.rqe/fvHyPxl2UH6r16ySb18IsLEeeGMwye', 1);`,
-  );
-  await connection.query(
-    'INSERT INTO EPICS(NAME, START_AT, END_AT, `ORDER`, PROJECT_ID)' +
-      `VALUES('에픽 api 테스트 작성', '2021-11-03 00:00:00', '2021-11-03 00:00:00', 0, 1);`,
-  );
-  await connection.query(
-    'INSERT INTO EPICS(NAME, START_AT, END_AT, `ORDER`, PROJECT_ID)' +
-      `VALUES('스토리 작성', '2021-11-02 00:00:00', '2021-11-04 00:00:00', 1, 1);`,
-  );
-  await connection.query(
-    'INSERT INTO EPICS(NAME, START_AT, END_AT, `ORDER`, PROJECT_ID)' +
-      `VALUES('네트워킹 데이 준비', '2021-11-04 00:00:00', '2021-11-06 00:00:00', 2, 1);`,
-  );
-  await connection.query(
-    'INSERT INTO EPICS(NAME, START_AT, END_AT, `ORDER`, PROJECT_ID)' +
-      `VALUES('부스트캠프 수료', '2021-11-04 00:00:00', '2021-11-06 00:00:00', 3, 1);`,
-  );
-});
-
-afterAll(async () => {
-  const connection = await getConnection();
-  await connection.query(`DELETE FROM USERS;`);
-  await connection.query(`DELETE FROM EPICS;`);
-  await connection.query(`DELETE FROM PROJECTS;`);
-  await connection.query(`DELETE FROM ORGANIZATIONS;`);
-  await connection.query('ALTER TABLE ORGANIZATIONS AUTO_INCREMENT = 1');
-  await connection.query('ALTER TABLE USERS AUTO_INCREMENT = 1');
-  await connection.query('ALTER TABLE PROJECTS AUTO_INCREMENT = 1');
-  await connection.query('ALTER TABLE EPICS AUTO_INCREMENT = 1');
-  await connection.close();
-});
+beforeAll(beforeAllfunction);
+afterAll(afterAllFunction);
 
 let Cookies = '';
 
@@ -74,81 +21,91 @@ beforeEach((done) => {
 });
 
 // FIXME: 세션에 사용자 mock
-test('전체 에픽 목록을 조회한다.', async () => {
-  const res = await request(app).get('/api/epics?projectId=1').set('Cookie', Cookies);
-  expect(res.status).toBe(200);
-});
-
-test('잘못된 projectId에 대해 응답코드 404을 반환한다.', async () => {
-  const res = await request(app).get('/api/epics?projectId=9999').set('Cookie', Cookies);
-  expect(res.status).toBe(404);
-});
-
-test('개별 에픽 정보 요청에 대한 응답을 반환한다.', async () => {
-  const res = await request(app).get('/api/epics/1').set('Cookie', Cookies);
-  expect(res.status).toBe(200);
-});
-
-test('잘못된 에픽 id로 보낸 요청에 대해 응답코드 404를 반환한다.', async () => {
-  const res = await request(app).get('/api/epics/9999').set('Cookie', Cookies);
-  expect(res.status).toBe(404);
-});
-
-test('에픽을 생성한다.', async () => {
-  const res = await request(app).post('/api/epics').set('Cookie', Cookies).send({
-    name: '새롭게 생성한 에픽',
-    projectId: 1,
-    startAt: new Date(),
-    endAt: new Date(),
-    order: 4,
+describe('에픽 목록 GET 요청', () => {
+  test('전체 에픽 목록을 조회한다.', async () => {
+    const res = await request(app).get('/api/epics?projectId=1').set('Cookie', Cookies);
+    expect(res.status).toBe(200);
   });
-  expect(res.status).toBe(201);
-  expect(res.body).toEqual({ id: 5 });
-});
 
-test('잘못된 에픽 생성 요청에 대해 응답코드 400을 반환한다.', async () => {
-  const res = await request(app).post('/api/epics').set('Cookie', Cookies).send({
-    name: '잘못된 에픽 생성 요청',
+  test('잘못된 projectId에 대해 응답코드 404을 반환한다.', async () => {
+    const res = await request(app).get('/api/epics?projectId=9999').set('Cookie', Cookies);
+    expect(res.status).toBe(404);
   });
-  expect(res.status).toBe(400);
 });
 
-test('에픽을 수정한다.', async () => {
-  const res = await request(app)
-    .patch('/api/epics/5')
-    .set('Cookie', Cookies)
-    .send({
-      name: '수정한 에픽',
+describe('개별 에픽 GET 요청', () => {
+  test('개별 에픽 정보 요청에 대한 응답을 반환한다.', async () => {
+    const res = await request(app).get('/api/epics/1').set('Cookie', Cookies);
+    expect(res.status).toBe(200);
+  });
+
+  test('잘못된 에픽 id로 보낸 요청에 대해 응답코드 404를 반환한다.', async () => {
+    const res = await request(app).get('/api/epics/9999').set('Cookie', Cookies);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('에픽 생성 요청', () => {
+  test('에픽을 생성한다.', async () => {
+    const res = await request(app).post('/api/epics').set('Cookie', Cookies).send({
+      name: '새롭게 생성한 에픽',
       projectId: 1,
-      startAt: new Date('2021-11-03'),
-      endAt: new Date('2021-11-03'),
-      order: 4,
+      startAt: new Date(),
+      endAt: new Date(),
+      order: 5,
     });
-  expect(res.status).toBe(200);
-  expect(res.body).toEqual({});
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ id: 6 });
+  });
 
-  // FIXME: 이 상태로는 get 요청까지 validate 함
-  // 어떻게 수정됐음을 확인할것인가?
-  const edited = await request(app).get('/api/epics/5').set('Cookie', Cookies);
-  expect(edited.status).toBe(200);
+  test('잘못된 에픽 생성 요청에 대해 응답코드 400을 반환한다.', async () => {
+    const res = await request(app).post('/api/epics').set('Cookie', Cookies).send({
+      name: '잘못된 에픽 생성 요청',
+    });
+    expect(res.status).toBe(400);
+  });
 });
 
-test('잘못된 에픽 수정 요청에 대해 응답코드 404을 반환한다.', async () => {
-  const res = await request(app)
-    .patch('/api/epics/9999')
-    .send({
-      name: '잘못 요청한 에픽',
-    })
-    .set('Cookie', Cookies);
-  expect(res.status).toBe(404);
+describe('에픽 수정 요청', () => {
+  test('에픽을 수정한다.', async () => {
+    const res = await request(app)
+      .patch('/api/epics/6')
+      .set('Cookie', Cookies)
+      .send({
+        name: '수정한 에픽',
+        projectId: 1,
+        startAt: new Date('2021-11-03'),
+        endAt: new Date('2021-11-03'),
+        order: 5,
+      });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({});
+
+    // FIXME: 이 상태로는 get 요청까지 validate 함
+    // 어떻게 수정됐음을 확인할것인가?
+    const edited = await request(app).get('/api/epics/5').set('Cookie', Cookies);
+    expect(edited.status).toBe(200);
+  });
+
+  test('잘못된 에픽 수정 요청에 대해 응답코드 404을 반환한다.', async () => {
+    const res = await request(app)
+      .patch('/api/epics/9999')
+      .send({
+        name: '잘못 요청한 에픽',
+      })
+      .set('Cookie', Cookies);
+    expect(res.status).toBe(404);
+  });
 });
 
-test('에픽을 삭제한다.', async () => {
-  const res = await request(app).delete('/api/epics/5').set('Cookie', Cookies);
-  expect(res.status).toBe(200);
-});
+describe('에픽 삭제 요청', () => {
+  test('에픽을 삭제한다.', async () => {
+    const res = await request(app).delete('/api/epics/5').set('Cookie', Cookies);
+    expect(res.status).toBe(200);
+  });
 
-test('잘못된 id로 에픽 삭제 요청을 보낼 시 응답코드 404을 반환한다.', async () => {
-  const res = await request(app).delete('/api/epics/9999').set('Cookie', Cookies);
-  expect(res.status).toBe(404);
+  test('잘못된 id로 에픽 삭제 요청을 보낼 시 응답코드 404을 반환한다.', async () => {
+    const res = await request(app).delete('/api/epics/9999').set('Cookie', Cookies);
+    expect(res.status).toBe(404);
+  });
 });

--- a/server/test/index.ts
+++ b/server/test/index.ts
@@ -52,7 +52,7 @@ export const beforeAllfunction = async () => {
   );
   await connection.query(
     'INSERT INTO EPICS(NAME, START_AT, END_AT, `ORDER`, PROJECT_ID)' +
-      `VALUES('마지막 에픽', '2021-11-5 00:00:00', '2021-11-06 00:00:00', 3, 2);`,
+      `VALUES('마지막 에픽', '2021-11-5 00:00:00', '2021-11-06 00:00:00', 4, 2);`,
   );
   // 스토리
   await connection.query(


### PR DESCRIPTION
## 😀 제목

todo 유효성 체크 수정 및 에픽 요청 필터링 수정

## ⛅️ 내용

> 이 PR의 작업 요약

- 긴 문자열에 대해 api 요청이 가지 않도록 return 문을 추가하였습니다.
- 올바르지 않은 projectId 인 경우와 에픽이 빈 배열인 경우를 올바르게 판단하도록 로직을 개선했습니다.
- 에픽 테스트 코드를 최신화 하였으며 중복 코드를 제거하고, 공통 주제 테스트 코드를 `describe` 로 묶었습니다.

## 🎸특이사항

> 리뷰시 참고할만한 내용, 주의깊게 봐줬으면 하는 내용

여기에 작성 
