### PR TITLE
프로젝트 아이디가 없을 때 스토리를 추가하지 못하도록 에러 핸들링

### DIFF
--- a/client/src/components/KanbanColumn/KanbanAddBtn/index.tsx
+++ b/client/src/components/KanbanColumn/KanbanAddBtn/index.tsx
@@ -30,6 +30,7 @@ const KanbanAddBtn = () => {
       order: listLargestOrder,
       projectId: userState.currentProjectId,
     });
+    if (storyId === undefined) return;
 
     setStoryList((prev) =>
       produce(prev, (draft) => {
@@ -41,8 +42,6 @@ const KanbanAddBtn = () => {
         });
       }),
     );
-
-    emitNewStory(storyId, userState.currentProjectId);
   };
 
   return (

--- a/client/src/lib/api/story.ts
+++ b/client/src/lib/api/story.ts
@@ -1,7 +1,7 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { toast } from 'react-toastify';
 import { StoryType } from '@/types/story';
-import { errorMessage } from '../common/message';
+import { errorMessage, warningMessage } from '../common/message';
 
 const instance = axios.create({
   baseURL: process.env.SERVER_URL + '/api/stories',
@@ -37,7 +37,11 @@ export const postStory = async ({ status, name, order, projectId, epicId }: Stor
     });
     return result.data.id;
   } catch (e) {
-    toast.error(errorMessage.CREATE_STORY);
+    if ((e as AxiosError).response?.status === 401) {
+      toast.warn(warningMessage.CREATE_STORY_WITHOUT_AUTH);
+    } else {
+      toast.error(errorMessage.CREATE_STORY);
+    }
   }
 };
 

--- a/client/src/lib/common/message/warning.ts
+++ b/client/src/lib/common/message/warning.ts
@@ -1,9 +1,11 @@
 export const ADMIN_ACCESS = '관리자 권한이 필요합니다.';
 export const MOVE_PROJECT = '현재 속한 프로젝트로만 이동이 가능합니다.';
 export const DELETE_MYSELF = '자신의 상태는 변경하실 수 없습니다.';
+export const CREATE_STORY_WITHOUT_AUTH = '프로젝티 관리 탭에서 프로젝트를 생성해주세요.';
 
 export default {
   ADMIN_ACCESS,
   MOVE_PROJECT,
   DELETE_MYSELF,
+  CREATE_STORY_WITHOUT_AUTH,
 };

--- a/server/src/Stories/Stories.controller.ts
+++ b/server/src/Stories/Stories.controller.ts
@@ -54,7 +54,6 @@ export const getStoryById = async (req: Request, res: Response) => {
       epicId: epics?.id,
     });
   } catch (e) {
-    console.log(e);
     res.status(404).json({
       message: (e as Error).message,
     });
@@ -63,7 +62,6 @@ export const getStoryById = async (req: Request, res: Response) => {
 
 export const postStory = async (req: Request, res: Response) => {
   try {
-    //TODO 생성 후 생성 결과를 반환하도록 query 문 작성
     const result = await getRepository(Stories)
       .createQueryBuilder()
       .insert()
@@ -79,9 +77,9 @@ export const postStory = async (req: Request, res: Response) => {
 
     res.json({ id: result.raw.insertId });
   } catch (e) {
-    res.status(400).json({
-      message: (e as Error).message,
-    });
+    const err = e as Error;
+    if (req.body.projectId === 0) res.status(401).json({ message: err.message });
+    else res.status(400).json({ message: err.message });
   }
 };
 


### PR DESCRIPTION
## 😀 제목

프로젝트 아이디가 없을 때 스토리를 추가하지 못하다록 에러 핸들링

## ⛅️ 내용

> 이 PR의 작업 요약

- 서버에서 status 코드를 다르게 보내도록 수정
- 스토리를 추가를 FE 와 소켓을 보내지 않게함
- 토스트 에러 메세지 추가

## 🎸특이사항

> 리뷰시 참고할만한 내용, 주의깊게 봐줬으면 하는 내용

여기에 작성 
