### PR TITLE
테스크 수정 시 프로젝트 ID 미할당 이슈 해결

### DIFF
--- a/client/src/components/KanbanModal/KanbanTask/index.tsx
+++ b/client/src/components/KanbanModal/KanbanTask/index.tsx
@@ -1,15 +1,19 @@
 import React, { useState } from 'react';
 import Styled from './style';
-import { useInput } from '@/lib/hooks';
-import { updateTask } from '@/lib/api/task';
 import { useRecoilValue } from 'recoil';
 import { userListAtom } from '@/recoil/user';
-import { KanbanTaskType } from '@/types/story';
-import { Modal } from '@/lib/design';
-import { useSocketSend } from '@/lib/hooks';
+import userAtom from '@/recoil/user';
+
 import TaskItemWithoutUser from '@/components/KanbanModal/TaskItemWithoutUser';
 import TaskItemWithUser from '@/components/KanbanModal/TaskItemWithUser';
+import { Modal } from '@/lib/design';
+
+import { updateTask } from '@/lib/api/task';
+import { useInput } from '@/lib/hooks';
+import { useSocketSend } from '@/lib/hooks';
 import { checkStringInput } from '@/lib/utils/bytes';
+
+import { KanbanTaskType } from '@/types/story';
 import { errorMessage } from '@/lib/common/message';
 import { toast } from 'react-toastify';
 import deleteIcon from '@public/icons/cancel-icon.svg';
@@ -26,6 +30,7 @@ const KanbanTask = ({ task, handleDelete }: KanbanTaskProps) => {
   const [showDelete, setShowDelete] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const userListState = useRecoilValue(userListAtom);
+  const userState = useRecoilValue(userAtom);
   const userListWithId = userListState.map((value) => {
     return { ...value, id: value.index };
   });
@@ -38,7 +43,13 @@ const KanbanTask = ({ task, handleDelete }: KanbanTaskProps) => {
       return;
     }
 
-    await updateTask(taskState.id as number, value, false, taskState.userId);
+    await updateTask(
+      taskState.id as number,
+      value,
+      false,
+      taskState.userId,
+      userState.currentProjectId,
+    );
     if (taskState.userId) emitNewTask(taskState.userId);
     setTask((prev) => ({
       ...prev,
@@ -51,7 +62,13 @@ const KanbanTask = ({ task, handleDelete }: KanbanTaskProps) => {
     if (target.tagName !== 'LI' || !taskState) return;
     const selectedUser = userListWithId.find((v) => v.index === target.value);
     if (!selectedUser) return;
-    await updateTask(Number(taskState.id), value, false, selectedUser.id);
+    await updateTask(
+      Number(taskState.id),
+      value,
+      false,
+      selectedUser.id,
+      userState.currentProjectId,
+    );
     emitNewTask(selectedUser.id);
     setTask((prev) => ({
       ...prev,

--- a/client/src/lib/api/task.ts
+++ b/client/src/lib/api/task.ts
@@ -17,13 +17,20 @@ export const getTasksByStoryId = async (storyId: number) => {
   }
 };
 
-export const updateTask = async (id: number, name: string, status: boolean, userId?: number) => {
+export const updateTask = async (
+  id: number,
+  name: string,
+  status: boolean,
+  userId?: number,
+  projectId?: number,
+) => {
   try {
     const result = await instance.patch('', {
       id,
       name,
       status,
       userId,
+      projectId,
     });
     if (result.status >= 400) throw Error();
   } catch (e) {

--- a/server/src/Tasks/Tasks.controller.ts
+++ b/server/src/Tasks/Tasks.controller.ts
@@ -38,6 +38,7 @@ export const getTasksByStoryId = async (req: Request, res: Response) => {
       relations: ['users'],
       where: { stories: { id: +req.params.id } },
     });
+
     res.status(200).json(
       tasks.map((el) => ({
         id: el.id,
@@ -63,6 +64,7 @@ export const updateTask = async (req: Request, res: Response) => {
       name: req.body.name,
       status: req.body.status,
       users: req.body.userId,
+      projects: req.body.projectId,
     });
     res.end();
   } catch (error) {


### PR DESCRIPTION
## 😀 제목

테스크 수정 시 프로젝트 ID 미할당 이슈 해결

## ⛅️ 내용

> 이 PR의 작업 요약

- 서버 Controller 에 ProjectID 를 반영하도록 수정
- 클라이언트 API ProjectID 반영하도록 수정 
- API 를 사용하는 칸반 모달에서 해당 인자를 전달하도록 수정

## 🎸특이사항

> 리뷰시 참고할만한 내용, 주의깊게 봐줬으면 하는 내용

없습니다 :) 
