### PR TITLE
에픽 드래그 인터랙션 보완 및 npm 명령어 수정

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "dev": "webpack-dev-server --progress",
+    "dev:bundle": "BUNDLE=true webpack-dev-server --progress",
     "build": "webpack --mode=production",
     "storybook": "start-storybook -s ./public -p 9001"
   },

--- a/client/src/components/EpicEntryItem/index.tsx
+++ b/client/src/components/EpicEntryItem/index.tsx
@@ -82,7 +82,8 @@ const EpicEntryItem = ({ handleDragStart, handleDrop, epicData, isEmpty }: EpicE
         onDragOver={(e) => e.preventDefault()}
         onDragEnter={() => setDragEntered(true)}
         onDragLeave={() => setDragEntered(false)}
-        onDrop={() => {
+        onDrop={(e) => {
+          e.stopPropagation();
           setDragEntered(false);
           handleDrop(epicData.order);
         }}

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -3,6 +3,27 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const Dotenv = require('dotenv-webpack');
 
+const loadPlugin = () => {
+  const plugins = [
+    new HtmlWebpackPlugin({
+      template: '/public/index.html',
+      favicon: 'public/favicon.ico',
+      minify:
+        process.env.NODE_ENV === 'production'
+          ? {
+              collapseWhitespace: true,
+              removeComments: true,
+            }
+          : false,
+    }),
+    new Dotenv(),
+  ];
+
+  const showBundle = !!process.env.BUNDLE;
+  if (process.env.BUNDLE) plugins.push(new BundleAnalyzerPlugin());
+  return plugins;
+};
+
 module.exports = {
   mode: 'development',
 
@@ -59,19 +80,5 @@ module.exports = {
     clean: true,
   },
 
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: '/public/index.html',
-      favicon: 'public/favicon.ico',
-      minify:
-        process.env.NODE_ENV === 'production'
-          ? {
-              collapseWhitespace: true,
-              removeComments: true,
-            }
-          : false,
-    }),
-    new BundleAnalyzerPlugin(),
-    new Dotenv(),
-  ],
+  plugins: loadPlugin(),
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:client" : "yarn workspace client build",
     "test:server": "yarn workspace server test",
     "test:client" : "yarn workspace client test",
+    "bundle:client" : "yarn workspace client dev:bundle",
     "ci": "echo 'hello' && yarn install --frozen-lockfile",
     "lint": "eslint ./"
   },


### PR DESCRIPTION
## 😀 제목

에픽 드래그 인터랙션 보완 및 npm 명령어 수정

## ⛅️ 내용

> 이 PR의 작업 요약

에픽 항목간 순서를 변경시키는 작업 시 올바른 영역에 드랍했음에도 토스트 에러를 발생시키는 문제를 해결했습니다
테스트 케이스의 필요성이 더더욱 느껴지네요 😥
webpack dev server 시작시마다 bundle analyzer 가 로드되는게 불편해서 bundle analyzer 플러그인을 위한 명령어를 따로 분리했습니다
bundle analyzer 화면을 보고싶으면 `npm run bundle:client` 를 실행시키면 됩니다

## 🎸특이사항

> 리뷰시 참고할만한 내용, 주의깊게 봐줬으면 하는 내용

