### PR TITLE
백로그 api 요청시 작업페이지 전체가 로딩되던 문제 해결

### DIFF
--- a/client/src/components/BackLogItem/index.tsx
+++ b/client/src/components/BackLogItem/index.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, Suspense } from 'react';
 import { useRecoilRefresher_UNSTABLE } from 'recoil';
 import S from './style';
 import arrow from '@public/icons/chevron-down.svg';
 
 import { tasksSelector } from '@/recoil/story';
-import BackLogTaskContainer from '../BackLogTaskContainer';
+import { Spinner } from '@/lib/design';
+
+const BackLogTaskContainer = React.lazy(() => import('../BackLogTaskContainer'));
 
 const BackLogItem = ({ name, id }: { name: string; id: number }) => {
   const [clicked, setClicked] = useState(false);
@@ -28,7 +30,11 @@ const BackLogItem = ({ name, id }: { name: string; id: number }) => {
           <S.ToggleImg src={arrow} click={clicked} />
         </S.ToggleButton>
       </S.ItemContainer>
-      {clicked && <BackLogTaskContainer storyId={id} />}
+      {clicked && (
+        <Suspense fallback={<Spinner widthLevel={8} heightValue={100} />}>
+          <BackLogTaskContainer storyId={id} />
+        </Suspense>
+      )}
     </div>
   );
 };

--- a/client/src/stories/Spinner.stories.tsx
+++ b/client/src/stories/Spinner.stories.tsx
@@ -15,4 +15,4 @@ export default {
 
 const Template: Story<SpinnerProps> = (args) => <Spinner {...args} />;
 
-export const DefaultSearchBar = (args: SpinnerProps) => <Template {...args}></Template>;
+export const DefaultSpinner = (args: SpinnerProps) => <Template {...args}></Template>;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:client" : "yarn workspace client build",
     "test:server": "yarn workspace server test",
     "test:client" : "yarn workspace client test",
+    "storybook" : "yarn workspace client storybook",
     "ci": "echo 'hello' && yarn install --frozen-lockfile",
     "lint": "eslint ./"
   },


### PR DESCRIPTION
## 😀 제목

백로그 api 요청시 작업페이지 전체가 로딩되던 문제 해결

## ⛅️ 내용

> 이 PR의 작업 요약

백로그에서 api요청으로 태스크를 받아올 때 작업페이지 전체가 스피너로 도는것을 확인했습니다.
리코일에서 비동기로 상태를 조회할 때 suspense로 감싸져있어야합니다. 하지만 백로그 아이템을 감싸는 것을 깜빡하여 리코일이 suspense를 찾아 올라가다 Router에서 스플리팅을 위해 작업페이지를 suspense로 감싼부분까지 타고올라간것으로 보입니다.
백로그 아이템을 Suspense로 감싸는것으로 해결했습니다.

## 🎸특이사항

> 리뷰시 참고할만한 내용, 주의깊게 봐줬으면 하는 내용

여기에 작성 
